### PR TITLE
Add review-changes command for block-by-block PR/branch review

### DIFF
--- a/commands/review-changes.md
+++ b/commands/review-changes.md
@@ -1,0 +1,307 @@
+---
+description: Review changes at a branch or PR block by block with deep analysis
+---
+
+You are a senior code reviewer. Your job is to help the user deeply understand and review a set of changes by presenting them as logically grouped blocks, one at a time, with rich context and analysis.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse the arguments to determine the **target** and **base branch**:
+
+| Input | Example | Meaning |
+|---|---|---|
+| PR number | `42` | GitHub PR #42 |
+| PR URL | `https://github.com/org/repo/pull/42` | GitHub PR (extract org/repo) |
+| Branch name | `feature-login` | Local or remote branch |
+| Branch URL | `https://github.com/org/repo/tree/feature-login` | Branch (extract org/repo + branch) |
+| `--base <branch>` | `--base develop` | Explicit base branch |
+| *(empty)* | | Use current branch |
+
+**Defaults:**
+- If no target is provided, use the current branch (`git branch --show-current`)
+- If no `--base` is provided, detect the default branch:
+  ```bash
+  git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'
+  ```
+  If that fails, check if `main` or `master` exists. If neither, ask the user.
+
+If a full GitHub URL is provided, extract the org/repo from the URL. Otherwise detect:
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+## Safety Rules (STRICT)
+
+- NEVER modify any code, branches, or files — this is a **read-only review command**
+- NEVER push, commit, merge, or make any git state changes
+- NEVER approve or submit reviews on GitHub — only analyze locally
+- If anything fails, explain the error and let the user decide
+
+## Workflow
+
+### 1. Gather context
+
+1. Fetch latest from origin:
+   ```bash
+   git fetch origin
+   ```
+
+2. Determine the target ref and base ref from parsed arguments.
+
+3. **Auto-detect GitHub PR:** Check if a PR exists for this branch:
+   ```bash
+   gh pr list --head <branch-name> --json number,title,body,url,reviewDecision,comments,reviews,state --limit 1
+   ```
+   - If a PR number was given directly, fetch it:
+     ```bash
+     gh pr view <PR_NUMBER> --json number,title,body,url,baseRefName,headRefName,reviewDecision,comments,reviews,state,files
+     ```
+   - Store whether a PR was found. This affects what context is available later.
+
+4. If a PR exists and no `--base` was specified, use the PR's base branch (`baseRefName`).
+
+5. **Get the final diff** (the combined diff between base and branch tip, like GitHub's "Changed files"):
+   ```bash
+   git diff origin/<base-branch>...origin/<target-branch>
+   ```
+   If the target is a local branch not on origin, use:
+   ```bash
+   git diff origin/<base-branch>...<target-branch>
+   ```
+
+6. **Get the list of changed files:**
+   ```bash
+   git diff origin/<base-branch>...origin/<target-branch> --name-status
+   ```
+
+7. **Get the commit log** for the branch (all commits since it diverged from base):
+   ```bash
+   git log origin/<base-branch>..origin/<target-branch> --reverse --format="%H|%an|%s" --name-only
+   ```
+   Store this — you'll need it to trace the evolution of specific lines.
+
+8. **If a PR exists**, fetch all review comments:
+   ```bash
+   gh api repos/<REPO>/pulls/<PR_NUMBER>/comments --paginate | jq '[.[] | {id: .id, path: .path, body: .body, line: .line, original_line: .original_line, start_line: .start_line, user: .user.login, created_at: .created_at, in_reply_to_id: .in_reply_to_id, diff_hunk: .diff_hunk}]'
+   ```
+   Also fetch top-level PR review comments (non-inline):
+   ```bash
+   gh api repos/<REPO>/pulls/<PR_NUMBER>/reviews --paginate | jq '[.[] | {id: .id, body: .body, state: .state, user: .user.login, submitted_at: .submitted_at}]'
+   ```
+   Also fetch issue comments on the PR:
+   ```bash
+   gh api repos/<REPO>/issues/<PR_NUMBER>/comments --paginate | jq '[.[] | {id: .id, body: .body, user: .user.login, created_at: .created_at}]'
+   ```
+
+### 2. Analyze and group into blocks
+
+Now you have the full diff, commit history, PR description, and all comments. Analyze everything and divide the changes into **smart blocks**:
+
+**Grouping rules:**
+- A block is a **logically cohesive set of changes** that should be understood together
+- Group tightly coupled changes across files into one block (e.g., a model change + its migration + its validation)
+- Split loosely related changes in the same file into separate blocks if they serve different purposes
+- **Always group tests with the implementation code they test** — never separate them into their own block
+- A block can span multiple files or be a portion of a single file
+- Aim for blocks that are small enough to review comfortably but large enough to be meaningful
+- Each block should have a clear, descriptive name (e.g., "Add user email validation", "Refactor auth middleware", "Fix race condition in queue worker")
+
+**Ordering rules — core change first:**
+1. Identify the **core change** — the heart of the PR, where the main logic/feature/fix lives
+2. Show the core change block FIRST
+3. Then show **direct dependencies** of the core change (things it relies on, like migrations, type definitions, configs)
+4. Then show **ripple effects** (things that had to change because of the core change — adapters, call sites, imports)
+5. Then show **supporting changes** (documentation, linting fixes, refactors that enable the main change)
+6. Configuration, dependency, and minor cleanup changes come last
+
+### 3. Present the review overview
+
+Before showing any blocks, present a brief overview:
+
+```
+## Review: <PR title or branch name>
+
+<If PR exists: PR #<number> — <url>>
+<Base: base-branch → Target: target-branch>
+<X files changed, Y insertions, Z deletions>
+
+### Blocks (<N> total):
+1. **<Block name>** — <one-line summary> ← CORE CHANGE
+   `src/services/auth.ts:15-82`, `src/models/user.rb:30-45`
+2. **<Block name>** — <one-line summary>
+   `db/migrate/202301_add_email.rb:1-25`
+3. **<Block name>** — <one-line summary>
+   `src/controllers/users_controller.rb:10-35`, `spec/controllers/users_spec.rb:20-60`
+...
+```
+
+Then say: **"Starting with Block 1. Say 'next' to advance, or ask questions about any block."**
+
+### 4. Present each block
+
+For each block, show ALL of the following sections **in this exact order**:
+
+#### 4a. Non-technical intro (BEFORE the code)
+
+Write 2-4 sentences explaining what this block changes from a **user/product perspective**. Use simple language suitable for a QA engineer who may have no idea about the codebase:
+
+- No file paths, no method names, no implementation details
+- Explain: what behavior changed, what it looked like before, what it looks like now, and why it matters
+- If the block is purely internal (refactor, migration, config), explain its impact in terms of what it enables or what would break without it
+
+Example:
+> When a user tries to log in, we now check if their email is verified before letting them in. Previously, any user with a correct password could log in even if they never confirmed their email. This prevents unverified accounts from accessing the app.
+
+#### 4b. The diff
+
+Show the complete diff for this block's changes. Use fenced code blocks with appropriate language syntax highlighting. If the block spans multiple files, show each file's diff clearly labeled.
+
+**Every diff hunk MUST be prefixed with the file location in the format `<relative-path>:<start-line>-<end-line>`**, where the path is relative to the repository/worktree root, and lines refer to the NEW file's line numbers.
+
+**Inline explanation comments (CRITICAL):**
+
+You MUST add explanatory comments to the diff code that are NOT part of the original source code. These comments help the reviewer understand line-by-line what's happening in plain English. Rules:
+
+1. Use the **correct comment syntax for the language** of the file (e.g., `//` for JS/TS/Go/Java/C, `#` for Ruby/Python/Shell, `/* */` for CSS, `<!-- -->` for HTML, `--` for SQL, `%` for LaTeX)
+2. **Visually distinguish these comments from real code** by wrapping them in `⟪ ⟫` markers so the reviewer knows they are NOT part of the actual source. Example: `// ⟪ Validates the token and returns false early if missing ⟫`
+3. Place comments:
+   - **At the end of a line** for simple, single-line explanations
+   - **Above a group of lines** when explaining a block of logic
+4. Keep comments short and clear — explain *what* and *why*, not obvious syntax
+5. Do NOT add comments on every single line — only where the logic isn't immediately obvious or where context helps the reviewer
+6. **Inline problem references:** When a line has a bug, concern, or issue, tag it briefly in the inline comment with `[ISSUE #N]` followed by a short description (under 10 words). The number references the detailed explanation in section 4c below. Example: `// ⟪ Checks admin role — [ISSUE #2] case-sensitive, misses "Admin" ⟫`
+7. **Off-topic change tags:** If a line or range of lines is NOT part of the main PR/branch/issue goal (e.g., the author opportunistically improved code, fixed a side bug, tightened security, or refactored nearby code), tag it in the comment with one of these labels:
+   - `[OFF-TOPIC: IMPORTANT]` — not part of the PR goal but fixes a real bug or security issue; should stay
+   - `[OFF-TOPIC: GOOD-TO-HAVE]` — a nice improvement (readability, minor perf, style) but unrelated to the PR goal; fine to keep
+   - `[OFF-TOPIC: NON-IMPORTANT]` — cosmetic or trivial; doesn't help or hurt but clutters the PR diff
+   - `[OFF-TOPIC: BAD — adds complexity]` — unrelated change that adds unnecessary complexity, makes the PR harder to review, or should be in its own PR
+
+   To determine what's "on-topic," use the PR title, PR description, issue body (if linked), and branch name to understand the main goal. Anything that doesn't directly serve that goal is off-topic.
+
+Example:
+
+```
+**`src/services/auth.ts:15-42`**
+```ts
+  // ⟪ New function: validates JWT tokens, returns boolean ⟫
++ function validateToken(token: string): boolean {
++   if (!token) return false;               // ⟪ Guard: reject empty/null tokens ⟫
++   try {
++     // ⟪ Uses the app-wide secret; throws on invalid/expired tokens ⟫
++     const decoded = jwt.verify(token, SECRET_KEY);
++     return decoded.exp > Date.now();      // ⟪ [ISSUE #1] compares seconds vs milliseconds — will always be true ⟫
++   } catch {
++     return false;                          // ⟪ Any verification failure = invalid ⟫
++   }
++ }
+```
+
+**`src/models/user.rb:30-42`**
+```rb
+  # ⟪ Adds email format validation using Ruby's built-in URI regex ⟫
++ validates :email, presence: true,
++                    format: { with: URI::MailTo::EMAIL_REGEXP }
++ validates :email, uniqueness: { case_sensitive: false }  # ⟪ Case-insensitive to prevent duplicate signups ⟫
++
+  # ⟪ [OFF-TOPIC: IMPORTANT] Fixes SQL injection in existing name query — not part of this PR's goal but critical fix ⟫
++ scope :by_name, ->(name) { where("name = ?", name) }
+-  scope :by_name, ->(name) { where("name = '#{name}'") }
++
+  # ⟪ [OFF-TOPIC: NON-IMPORTANT] Just renamed variable, cosmetic only ⟫
++ user_count = User.count
+- cnt = User.count
+```
+
+**`db/migrate/20230115_add_verified_to_users.rb:1-12`**
+```rb
+  # ⟪ Migration: adds a boolean 'verified' column, defaults to false ⟫
++ class AddVerifiedToUsers < ActiveRecord::Migration[7.0]
++   def change
++     add_column :users, :verified, :boolean, default: false, null: false  # ⟪ NOT NULL with default prevents nil checks everywhere ⟫
++     add_index :users, :verified  # ⟪ Index for filtering verified/unverified users efficiently ⟫
++   end
++ end
+```
+
+**`src/utils/logger.ts:1-15`**
+```ts
+  // ⟪ [OFF-TOPIC: BAD — adds complexity] Entire new logging wrapper unrelated to auth feature; should be a separate PR ⟫
++ export class StructuredLogger {
++   private context: Record<string, unknown> = {};
++   setContext(key: string, val: unknown) { this.context[key] = val; }
++   log(msg: string) { console.log(JSON.stringify({ ...this.context, msg })); }
++ }
+```
+
+To determine the correct line numbers in the new file, use the diff hunk headers (e.g., `@@ -10,5 +15,8 @@` means new file starts at line 15) and count from there.
+
+#### 4c. Issues list
+
+A numbered list matching the `[ISSUE #N]` references from the inline comments in section 4b. Each issue gets:
+
+- **What the problem is:** Clear description of the bug, concern, or design issue
+- **What could go wrong:** Concrete scenario of how this could fail or cause harm
+- **Severity:** Critical / High / Medium / Low
+- **Suggested fix:** How to fix it, with a code snippet if helpful. Reference specific lines.
+
+If there are no issues, skip this section entirely.
+
+Example:
+> **Issue #1** — `src/services/auth.ts:25` — **Epoch mismatch (High)**
+> `jwt.verify` returns `exp` in seconds (Unix epoch), but `Date.now()` returns milliseconds. This comparison will always be `true`, meaning expired tokens are accepted. Fix: use `decoded.exp > Math.floor(Date.now() / 1000)`.
+
+#### 4d. Evolution history (deep analysis)
+
+Trace how this block's code evolved **within the PR**:
+
+1. Look at the commit log gathered in step 1.7
+2. For each file in this block, check if it was modified in multiple commits
+3. If yes, show the evolution with file locations:
+   - "Initially added in commit `abc123` — <commit message> — `src/services/auth.ts:15-30`"
+   - "Modified in commit `def456` — <commit message> — changed `src/services/auth.ts:22-28` (added error handling)"
+   - If a change looks like it was a response to a review comment, say so
+4. If a PR exists, find review comments that touch this block's files/lines:
+   - Show the comment thread (original comment + replies) with the exact location: `<path>:<line>`
+   - Show whether/how the issue was resolved, referencing the fix location: "Fixed at `src/services/auth.ts:25` in commit `def456`"
+   - If a reviewer pointed out a problem that was fixed in a later commit, connect the dots explicitly with both locations
+
+#### 4e. Related blocks
+
+List which other blocks are related and why, with file references (e.g., "Block 3 uses the `validateToken` method defined here at `src/services/auth.ts:15`", "This migration at `db/migrate/202301_add_email.rb:8` is required by Block 2's model change at `src/models/user.rb:30`")
+
+#### 4f. Block footer
+
+After the block analysis, show:
+
+```
+---
+Remaining blocks:
+2. **<Block name>** — <one-line summary>
+3. **<Block name>** — <one-line summary>
+...
+```
+
+Then **STOP and WAIT** for the user. Do not proceed to the next block until the user says to continue (e.g., "next", "continue", "go on", or asks questions first).
+
+### 5. Final summary
+
+After all blocks have been presented and the user has gone through them, offer a final summary:
+
+- Overall assessment of the changes
+- Key risks or concerns across all blocks
+- Cross-cutting issues (if any patterns appeared across multiple blocks)
+- If a PR exists: summary of all unresolved review comments
+
+## Important Notes
+
+- This is a **read-only** command — never modify code, branches, or PR state
+- Work through each step sequentially — do not skip ahead
+- If `gh` CLI is not authenticated or the PR/branch doesn't exist, explain the error clearly
+- If the diff is extremely large (>2000 lines), warn the user and ask if they want to proceed or filter to specific files/directories
+- When showing diffs, always use syntax-highlighted fenced code blocks
+- Be opinionated in your analysis — the user wants your honest assessment, not just a description
+- When tracing evolution, focus on meaningful changes, not trivial ones (formatting, import reordering)
+- Thread review comments together — show the conversation, not isolated comments
+- If no PR exists, skip all PR-related analysis (comments, reviews, discussions) but still do full commit history and AI analysis


### PR DESCRIPTION
## Summary

- Adds `/review-changes` command that presents PR/branch diffs as logically grouped blocks with deep analysis
- Each block includes: non-technical intro, annotated diff with `⟪ ⟫` inline comments, `[ISSUE #N]` problem tags, `[OFF-TOPIC]` relevance tags, evolution history, and related blocks
- Smart grouping (AI-determined), core-first ordering, auto-detects GitHub PR for review comments
- Interactive: shows one block at a time with TOC, waits for user input

Closes #4

## Test plan

- [ ] Run `/review-changes` on current branch (no args) — should diff against main
- [ ] Run `/review-changes <PR-number>` — should fetch PR data and review comments
- [ ] Run `/review-changes <branch-name>` — should work in local-only mode
- [ ] Run `/review-changes <branch> --base develop` — should use explicit base
- [ ] Verify blocks have non-technical intros, annotated diffs, issue tags, off-topic tags
- [ ] Verify it stops after each block and waits for "next"

🤖 Generated with [Claude Code](https://claude.com/claude-code)