### PR TITLE
Add parallel workflow commands for worktree-based development

### DIFF
--- a/commands/cleanup-worktree.md
+++ b/commands/cleanup-worktree.md
@@ -1,0 +1,121 @@
+---
+description: Safely clean up a single worktree (current or specified)
+---
+
+Clean up a single git worktree, handling uncommitted changes and unpushed commits safely.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse the arguments to determine which worktree to clean up:
+
+- No arguments: clean up the **current** worktree (must be a worktree, not the main working tree)
+- Path: clean up the worktree at the given path (e.g. `.claude/worktrees/my-feature`)
+- Branch name: find and clean up the worktree associated with that branch
+
+## Safety Rules (STRICT)
+
+- NEVER remove the main working tree
+- NEVER discard uncommitted changes without explicit confirmation
+- NEVER delete an unmerged branch without explicit confirmation
+- NEVER force-delete a branch (`git branch -D`) — use `git branch -d` and ask if it fails
+- If anything goes wrong unexpectedly, explain the problem and let me decide how to proceed
+
+## Workflow
+
+### 1. Identify the target worktree
+
+1. List all worktrees:
+   ```bash
+   git worktree list --porcelain
+   ```
+
+2. Determine the target:
+   - **No arguments:** use the current working directory. Verify it is a worktree (not the main working tree) by checking if `git rev-parse --path-format=absolute --git-common-dir` differs from `git rev-parse --path-format=absolute --git-dir`
+   - **Path provided:** resolve to absolute path, find matching worktree
+   - **Branch name provided:** find the worktree with that branch checked out
+
+3. If no matching worktree is found, list available worktrees and ask me to clarify
+
+4. Record the worktree path and its branch name for later steps
+
+### 2. Check for uncommitted changes
+
+1. Check for unstaged, staged, and untracked files:
+   ```bash
+   git -C <worktree-path> status --porcelain
+   ```
+
+2. If there are changes, show them and present options:
+   - **Commit:** create a WIP commit with the changes
+   - **Stash:** stash the changes (note: stash is global, not per-worktree)
+   - **Discard:** discard all changes (requires explicit confirmation)
+   - **Abort:** stop the cleanup
+
+3. **Wait for my choice** before proceeding
+
+### 3. Check for unpushed commits
+
+1. Check for unpushed commits:
+   ```bash
+   git -C <worktree-path> log @{upstream}..HEAD --oneline 2>/dev/null
+   ```
+   - If no upstream is set, try:
+     ```bash
+     git -C <worktree-path> log origin/<branch>..HEAD --oneline 2>/dev/null
+     ```
+   - If neither works, check if the branch has any commits not on the default branch
+
+2. If there are unpushed commits, show them and present options:
+   - **Push:** push the branch to origin
+   - **Continue:** proceed without pushing (commits will be lost if branch is deleted)
+   - **Abort:** stop the cleanup
+
+3. **Wait for my choice** before proceeding
+
+### 4. Remove the worktree
+
+1. Remove the worktree:
+   ```bash
+   git worktree remove <worktree-path>
+   ```
+   - If this fails (e.g. dirty tree), explain the error and ask how to proceed
+
+### 5. Clean up the branch
+
+1. Check if the branch is merged into the default branch:
+   ```bash
+   git branch --merged <default-branch> | grep -w <branch-name>
+   ```
+
+2. **If merged:** delete the branch:
+   ```bash
+   git branch -d <branch-name>
+   ```
+
+3. **If not merged:** inform me and ask whether to:
+   - **Delete anyway** (will use `git branch -D` only with explicit confirmation)
+   - **Keep the branch** for later use
+
+4. **Wait for my choice** if the branch is not merged
+
+### 6. Final cleanup
+
+1. Prune stale worktree references:
+   ```bash
+   git worktree prune
+   ```
+
+2. Show a summary of what was done:
+   - Worktree path removed
+   - Branch deleted (or kept)
+   - Any stashed/committed changes
+
+## Important Notes
+
+- Always confirm before any destructive action (discarding changes, deleting unmerged branches)
+- If the current directory IS the worktree being removed, warn that the shell will be in a deleted directory after cleanup
+- The default branch detection uses the same method as `rebase-branch.md`:
+  - `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`
+  - Fallback: check for `main` or `master`

--- a/commands/cleanup-worktrees.md
+++ b/commands/cleanup-worktrees.md
@@ -1,0 +1,170 @@
+---
+description: Scan all worktrees and batch clean up merged ones
+---
+
+Scan ALL worktrees, auto-remove merged+clean ones, prompt for merged+dirty ones, and skip unmerged ones.
+
+Arguments: $ARGUMENTS
+
+## Safety Rules (STRICT)
+
+- NEVER remove the main working tree
+- NEVER auto-remove a worktree with uncommitted changes or unpushed commits — always ask first
+- NEVER delete an unmerged branch without explicit confirmation
+- NEVER force-delete a branch (`git branch -D`) — use `git branch -d` and ask if it fails
+- ALWAYS present a scan summary and wait for confirmation before removing anything
+- If anything goes wrong unexpectedly, explain the problem and let me decide how to proceed
+
+## Workflow
+
+### 1. Detect the default branch
+
+1. Detect the repo's default branch:
+   - Run: `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`
+   - If that fails, check if `main` or `master` exists locally: `git rev-parse --verify main 2>/dev/null || git rev-parse --verify master 2>/dev/null`
+   - If neither is found, ask me which branch to use
+
+2. Fetch latest from origin:
+   ```bash
+   git fetch origin
+   ```
+
+### 2. Scan all worktrees
+
+1. List all worktrees:
+   ```bash
+   git worktree list --porcelain
+   ```
+
+2. Identify the main working tree (the first entry — where `.git` is a directory, not a file) and exclude it from processing
+
+3. For each remaining worktree, gather:
+   - **Worktree path**
+   - **Branch name** (from the `branch` field, strip `refs/heads/` prefix)
+   - **Detached HEAD** (if `HEAD` is detached, flag it)
+
+### 3. Classify each worktree
+
+For each worktree (excluding main), determine its state:
+
+#### Merge detection
+
+A branch is considered "merged" if **either** condition is true:
+
+1. **Ancestor check** — the branch tip is an ancestor of the default branch:
+   ```bash
+   git merge-base --is-ancestor <branch> origin/<default-branch>
+   ```
+
+2. **Empty diff heuristic** (catches squash merges) — no diff between the branch and the default branch:
+   ```bash
+   git diff origin/<default-branch>...<branch> --quiet
+   ```
+
+#### Dirty state checks
+
+Run these inside the worktree:
+
+1. **Uncommitted changes** (unstaged, staged, untracked):
+   ```bash
+   git -C <worktree-path> status --porcelain
+   ```
+
+2. **Unpushed commits:**
+   ```bash
+   git -C <worktree-path> log @{upstream}..HEAD --oneline 2>/dev/null
+   ```
+   - If no upstream is set, fall back to:
+     ```bash
+     git -C <worktree-path> log origin/<default-branch>..HEAD --oneline 2>/dev/null
+     ```
+
+#### Classification
+
+- **Merged + Clean** — merged and no dirty state → auto-remove candidate
+- **Merged + Dirty** — merged but has uncommitted changes or unpushed commits → prompt per worktree
+- **Not merged** — not merged regardless of dirty state → skip, report only
+- **Detached HEAD** — HEAD is detached → skip, report only
+
+### 4. Present scan summary
+
+Display a summary table before taking any action:
+
+```
+Worktree Scan Results
+=====================
+
+Auto-remove (merged + clean):
+  - .claude/worktrees/42-fix-login (branch: 42-fix-login-bug)
+  - .claude/worktrees/15-update-docs (branch: 15-update-docs)
+
+Needs confirmation (merged + dirty):
+  - .claude/worktrees/33-refactor-api (branch: 33-refactor-api)
+    Dirty: 2 uncommitted files, 1 unpushed commit
+
+Skipped (not merged):
+  - .claude/worktrees/50-new-feature (branch: 50-new-feature) — 3 commits ahead
+
+Skipped (detached HEAD):
+  - .claude/worktrees/experiment (HEAD detached at abc1234)
+```
+
+**Wait for my confirmation** before proceeding with removals.
+
+### 5. Auto-remove merged + clean worktrees
+
+For each merged+clean worktree:
+
+1. Remove the worktree:
+   ```bash
+   git worktree remove <worktree-path>
+   ```
+
+2. Delete the branch:
+   ```bash
+   git branch -d <branch-name>
+   ```
+
+3. Report each removal as it happens
+
+### 6. Handle merged + dirty worktrees
+
+For each merged+dirty worktree, show the dirty details:
+
+1. Show uncommitted changes:
+   ```bash
+   git -C <worktree-path> status --short
+   ```
+
+2. Show unpushed commits (if any):
+   ```bash
+   git -C <worktree-path> log @{upstream}..HEAD --oneline 2>/dev/null
+   ```
+
+3. Present options for this worktree:
+   - **Remove anyway** — discard changes and remove
+   - **Stash first** — stash changes, then remove worktree and branch
+   - **Skip** — leave this worktree alone
+
+4. **Wait for my choice** before proceeding to the next dirty worktree
+
+### 7. Final cleanup
+
+1. Prune stale worktree references:
+   ```bash
+   git worktree prune
+   ```
+
+2. Show a final summary:
+   - Number of worktrees removed
+   - Number of branches deleted
+   - Number of worktrees skipped (and why)
+   - Any worktrees that remain
+
+## Important Notes
+
+- Always present the full scan summary before removing anything
+- Process auto-removals first, then prompt for dirty worktrees one by one
+- If a worktree removal fails, report the error and continue with the rest
+- If the current directory is one of the worktrees being removed, warn about it before proceeding
+- The empty-diff heuristic for squash merges may have false positives on branches with no commits — handle gracefully

--- a/commands/start-issue.md
+++ b/commands/start-issue.md
@@ -1,0 +1,137 @@
+---
+description: Create a branch and worktree from a GitHub issue for parallel development
+---
+
+Given a GitHub issue number or URL, create a branch + worktree and show issue context. Smart enough to detect the correct base branch.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse the arguments to extract the issue number and optional base branch override. Examples:
+
+- `42` — issue number
+- `https://github.com/org/repo/issues/42` — issue URL (extract org/repo and issue number)
+- `42 --base develop` — issue number with explicit base branch
+- `42 --base origin/release-2.0` — issue number with explicit remote base branch
+
+If a full GitHub URL is provided, extract the org/repo from the URL. Otherwise, detect the current repo:
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+## Safety Rules (STRICT)
+
+- NEVER start coding or making changes automatically — always wait for user instructions after setup
+- NEVER delete or overwrite an existing branch without explicit confirmation
+- NEVER force push or run destructive git commands
+- If anything goes wrong unexpectedly, explain the problem and let me decide how to proceed
+
+## Workflow
+
+### 1. Fetch issue details
+
+1. Parse the arguments to extract the issue number (and optional `--base <branch>`)
+2. Fetch issue details:
+   ```bash
+   gh issue view <NUMBER> --json number,title,body,labels,assignees,state,comments
+   ```
+3. If the issue is closed, warn me and ask whether to proceed
+
+### 2. Determine the base branch
+
+**If `--base <branch>` was provided**, use it directly — skip to step 3.
+
+**Otherwise**, gather candidate branches:
+
+1. **Detect the repo's default branch:**
+   - Run: `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`
+   - If that fails, check if `main` or `master` exists locally: `git rev-parse --verify main 2>/dev/null || git rev-parse --verify master 2>/dev/null`
+   - If neither is found, ask me which branch to use
+
+2. **Scan issue body and comments** for branch references:
+   - Look for patterns like "merge into `develop`", "target: `release-2.0`", "base branch: `staging`", "branch: `feature-x`"
+   - Look for backtick-wrapped or quoted branch names near keywords: target, base, merge, branch, into
+
+3. **Check if the issue references any PRs:**
+   - Use GitHub's rendered HTML to extract PR references reliably (GitHub auto-links `#<number>` and tags PRs with `data-hovercard-type="pull_request"`):
+     ```bash
+     gh api -H "Accept: application/vnd.github.html+json" repos/<REPO>/issues/<NUMBER> \
+       --jq '.body_html' \
+       | grep -oE 'data-hovercard-type="pull_request"[^>]*href="[^"]*/(pull|issues)/([0-9]+)"' \
+       | grep -oE '[0-9]+$' | sort -u
+     ```
+   - For each referenced PR number, fetch its base and head branches:
+     ```bash
+     gh pr view <PR_NUMBER> --repo <REPO> --json baseRefName,headRefName -q '{base: .baseRefName, head: .headRefName}'
+     ```
+   - Add both the PR base branch and PR head branch as candidates
+
+4. **Choose the base branch:**
+   - If only the default branch was found (no PR references, no branch mentions), use it without asking
+   - If multiple candidates were found, present all discovered branches as options and ask me to pick one
+   - List each candidate with context on where it was found (e.g. "default branch", "mentioned in issue body", "PR #123 base branch")
+
+### 3. Set up the branch and worktree
+
+1. Fetch latest from origin:
+   ```bash
+   git fetch origin
+   ```
+
+2. Generate branch name: `<issue-number>-<slugified-title>`
+   - Slugify: lowercase, replace spaces/special chars with hyphens, collapse multiple hyphens, trim to reasonable length (max ~50 chars), strip trailing hyphens
+   - Example: issue #42 "Fix Login Bug" → `42-fix-login-bug`
+
+3. Check if a branch with this name already exists (local or remote):
+   ```bash
+   git rev-parse --verify <branch-name> 2>/dev/null
+   git rev-parse --verify origin/<branch-name> 2>/dev/null
+   ```
+   - If it exists, ask me how to proceed: use the existing branch, choose a different name, or abort
+
+4. Create the branch from `origin/<base-branch>`:
+   ```bash
+   git branch <branch-name> origin/<base-branch>
+   ```
+
+5. Enter the worktree using the `EnterWorktree` tool with the branch name
+
+6. Inside the worktree, checkout the new branch:
+   ```bash
+   git checkout <branch-name>
+   ```
+
+### 4. Present issue summary
+
+Display a clear summary:
+
+- **Issue:** #\<number\> — \<title\>
+- **State:** \<open/closed\>
+- **Labels:** \<labels or "none"\>
+- **Assignees:** \<assignees or "unassigned"\>
+- **Base branch:** \<base-branch\>
+- **New branch:** \<branch-name\>
+- **Worktree path:** \<path\>
+- **Body:** show the issue body (truncated if very long)
+
+### 5. Name the session
+
+Rename the current Claude Code session so it's easy to find later with `claude --resume`:
+
+```
+/rename issue-<number>-<short-slug>
+```
+
+For example: `/rename issue-42-fix-login-bug`
+
+### 6. Wait for instructions
+
+**STOP here.** Do NOT auto-start coding. Wait for me to tell you what to do with this issue.
+
+## Important Notes
+
+- Work through each step sequentially — do not skip ahead
+- If `gh` CLI is not authenticated or the issue doesn't exist, explain the error clearly
+- If the issue is from a different repo than the current one (URL-based), make sure to use the correct repo for `gh` commands
+- The branch name should be deterministic from the issue — same issue always produces the same branch name

--- a/commands/start-subtask-worktree.md
+++ b/commands/start-subtask-worktree.md
@@ -1,0 +1,149 @@
+---
+description: Create a temporary branch and worktree for an isolated subtask of an issue
+---
+
+Create a **temporary branch + worktree** for a specific subtask of a GitHub issue. The branch is based on the current HEAD of the issue's branch (not main). Use this when the subtask needs isolated file changes that shouldn't interfere with the main issue work.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse the arguments to extract the issue number, subtask name, and optional `--fork` flag. Examples:
+
+- `42 db-migration` — issue number + subtask name
+- `42 refactor-auth --fork` — with fork flag
+- `https://github.com/org/repo/issues/42 schema-update` — issue URL + subtask name
+
+The subtask name should be a short hyphenated slug (e.g. `db-migration`, `refactor-auth`, `add-tests`).
+
+If a full GitHub URL is provided, extract the org/repo from the URL. Otherwise, detect the current repo:
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+## Safety Rules (STRICT)
+
+- NEVER start coding or making changes automatically — always wait for user instructions after setup
+- NEVER delete or overwrite an existing branch without explicit confirmation
+- NEVER force push or run destructive git commands
+- The temporary branch is based on the **issue branch's HEAD**, NOT on main/master
+- If anything goes wrong unexpectedly, explain the problem and let me decide how to proceed
+
+## Workflow
+
+### 1. Parse arguments and handle fork
+
+1. Extract the issue number (or URL), subtask name, and `--fork` flag from the arguments
+2. If `--fork` is present:
+   - Run `/fork issue-<number>-<subtask-name>` to fork the current session and name it
+   - This makes the session independent from the original — proceed with the rest of the workflow
+
+### 2. Fetch issue details
+
+1. Fetch issue details:
+   ```bash
+   gh issue view <NUMBER> --json number,title,body,labels,assignees,state,comments
+   ```
+2. If the issue doesn't exist or `gh` fails, explain the error clearly
+
+### 3. Find the existing issue worktree
+
+1. List all worktrees:
+   ```bash
+   git worktree list --porcelain
+   ```
+
+2. Find the worktree whose branch starts with `<issue-number>-` (strip `refs/heads/` from the `branch` field)
+
+3. If no matching worktree is found:
+   - Show an error: "No worktree found for issue #\<number\>. Run `/start-issue <number>` first to create one."
+   - **STOP** — do not proceed
+
+4. Record the issue worktree path and its branch name (this is the **parent branch**)
+
+### 4. Build subtask context
+
+1. Tokenize the subtask name into keywords (split on hyphens):
+   - e.g. `db-migration` → `db`, `migration`
+
+2. Search the issue body for relevant content:
+   - Look for paragraphs, bullet points, or checklist items containing any of the keywords
+   - Look for markdown headings/sections that match
+   - Extract matching content with 2-3 lines of surrounding context
+
+3. Search the issue comments for relevant content:
+   - Same keyword matching as above
+   - Include the comment author for context
+
+4. If matches are found:
+   - Compile them into a **"Subtask Context"** section
+   - Group by source (issue body vs. specific comments)
+
+5. If no specific matches are found:
+   - Note: "No specific context found for subtask '\<subtask-name\>' in the issue"
+   - Show the full issue body so the user has all available context
+
+### 5. Create the subtask branch
+
+1. Get the current HEAD of the issue branch:
+   ```bash
+   git -C <issue-worktree-path> rev-parse HEAD
+   ```
+
+2. Generate the subtask branch name: `<issue-number>-<subtask-name>`
+   - Example: issue #42, subtask `db-migration` → `42-db-migration`
+
+3. Check if a branch with this name already exists:
+   ```bash
+   git rev-parse --verify <subtask-branch> 2>/dev/null
+   git rev-parse --verify origin/<subtask-branch> 2>/dev/null
+   ```
+   - If it exists, ask me how to proceed: use the existing branch, choose a different name, or abort
+   - **Wait for my choice** before proceeding
+
+4. Create the branch from the issue branch's HEAD:
+   ```bash
+   git branch <subtask-branch> <issue-branch-HEAD-commit>
+   ```
+
+### 6. Enter the worktree
+
+1. Enter the worktree using the `EnterWorktree` tool with the subtask branch name
+
+2. Inside the worktree, checkout the subtask branch:
+   ```bash
+   git checkout <subtask-branch>
+   ```
+
+### 7. Name the session
+
+If `--fork` was NOT used (session was not already named by the fork):
+```
+/rename issue-<number>-<subtask-name>
+```
+
+For example: `/rename issue-42-db-migration`
+
+### 8. Present summary
+
+Display a clear summary:
+
+- **Issue:** #\<number\> — \<title\>
+- **Subtask:** \<subtask-name\>
+- **Parent branch:** \<issue-branch\> (from `/start-issue`)
+- **Subtask branch:** \<subtask-branch\> (new, based on parent HEAD)
+- **Worktree path:** \<new-worktree-path\>
+- **Session name:** issue-\<number\>-\<subtask-name\>
+- **Subtask Context:** show the extracted context (or note that none was found)
+
+### 9. Wait for instructions
+
+**STOP here.** Do NOT auto-start coding. Wait for me to tell you what to do with this subtask.
+
+## Important Notes
+
+- The subtask branch is based on the **issue branch's HEAD**, not on main/master — this ensures the subtask starts with all the issue work done so far
+- Use `/cleanup-worktree` to clean up the subtask worktree when done
+- If the subtask changes need to be merged back into the issue branch, that's a separate step (e.g. cherry-pick or merge)
+- If `gh` CLI is not authenticated or the issue doesn't exist, explain the error clearly
+- The subtask branch name is deterministic: `<issue-number>-<subtask-name>`

--- a/commands/start-subtask.md
+++ b/commands/start-subtask.md
@@ -1,0 +1,122 @@
+---
+description: Start a subtask session in the existing issue worktree (same branch)
+---
+
+Open a new session focused on a specific subtask of a GitHub issue, working in the **same worktree and branch** that was created by `/start-issue`. Fetches the issue and extracts context relevant to the subtask.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse the arguments to extract the issue number, subtask name, and optional `--fork` flag. Examples:
+
+- `42 api-validation` — issue number + subtask name
+- `42 write-tests --fork` — with fork flag
+- `https://github.com/org/repo/issues/42 db-migration` — issue URL + subtask name
+
+The subtask name should be a short hyphenated slug (e.g. `api-validation`, `write-tests`, `fix-styling`).
+
+If a full GitHub URL is provided, extract the org/repo from the URL. Otherwise, detect the current repo:
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+## Safety Rules (STRICT)
+
+- NEVER create a new branch — this command reuses the existing issue branch
+- NEVER create a new worktree — this command reuses the existing issue worktree
+- NEVER start coding or making changes automatically — always wait for user instructions after setup
+- If anything goes wrong unexpectedly, explain the problem and let me decide how to proceed
+
+## Workflow
+
+### 1. Parse arguments and handle fork
+
+1. Extract the issue number (or URL), subtask name, and `--fork` flag from the arguments
+2. If `--fork` is present:
+   - Run `/fork issue-<number>-<subtask-name>` to fork the current session and name it
+   - This makes the session independent from the original — proceed with the rest of the workflow
+
+### 2. Fetch issue details
+
+1. Fetch issue details:
+   ```bash
+   gh issue view <NUMBER> --json number,title,body,labels,assignees,state,comments
+   ```
+2. If the issue doesn't exist or `gh` fails, explain the error clearly
+
+### 3. Find the existing worktree
+
+1. List all worktrees:
+   ```bash
+   git worktree list --porcelain
+   ```
+
+2. Find the worktree whose branch starts with `<issue-number>-` (strip `refs/heads/` from the `branch` field)
+
+3. If no matching worktree is found:
+   - Show an error: "No worktree found for issue #\<number\>. Run `/start-issue <number>` first to create one."
+   - **STOP** — do not proceed
+
+4. Record the worktree path and branch name
+
+### 4. Build subtask context
+
+1. Tokenize the subtask name into keywords (split on hyphens):
+   - e.g. `api-validation` → `api`, `validation`
+
+2. Search the issue body for relevant content:
+   - Look for paragraphs, bullet points, or checklist items containing any of the keywords
+   - Look for markdown headings/sections that match
+   - Extract matching content with 2-3 lines of surrounding context
+
+3. Search the issue comments for relevant content:
+   - Same keyword matching as above
+   - Include the comment author for context
+
+4. If matches are found:
+   - Compile them into a **"Subtask Context"** section
+   - Group by source (issue body vs. specific comments)
+
+5. If no specific matches are found:
+   - Note: "No specific context found for subtask '\<subtask-name\>' in the issue"
+   - Show the full issue body so the user has all available context
+
+### 5. Move to the worktree
+
+1. Change the working directory to the worktree path:
+   ```bash
+   cd <worktree-path>
+   ```
+
+### 6. Name the session
+
+If `--fork` was NOT used (session was not already named by the fork):
+```
+/rename issue-<number>-<subtask-name>
+```
+
+For example: `/rename issue-42-api-validation`
+
+### 7. Present summary
+
+Display a clear summary:
+
+- **Issue:** #\<number\> — \<title\>
+- **Subtask:** \<subtask-name\>
+- **Branch:** \<branch-name\> (shared with main issue session)
+- **Worktree path:** \<path\>
+- **Session name:** issue-\<number\>-\<subtask-name\>
+- **Subtask Context:** show the extracted context (or note that none was found)
+
+### 8. Wait for instructions
+
+**STOP here.** Do NOT auto-start coding. Wait for me to tell you what to do with this subtask.
+
+## Important Notes
+
+- This command does NOT create branches or worktrees — it reuses what `/start-issue` created
+- Multiple subtask sessions can work in the same worktree simultaneously (on different files)
+- Be careful about file conflicts when multiple sessions share the same worktree
+- The subtask name is used for session naming only — it does not affect the branch name
+- If `gh` CLI is not authenticated or the issue doesn't exist, explain the error clearly


### PR DESCRIPTION
## Summary

- Adds `/start-issue` command: creates a branch + worktree from a GitHub issue with smart base branch detection (uses GitHub's rendered HTML API to reliably find PR references)
- Adds `/start-subtask` command: opens a subtask session in the existing issue worktree (same branch), with `--fork` support via `/fork`
- Adds `/start-subtask-worktree` command: creates a temporary branch + worktree from the issue branch's HEAD for isolated subtask work, with `--fork` support
- Adds `/cleanup-worktree` command: safely cleans up a single worktree with checks for uncommitted changes and unpushed commits
- Adds `/cleanup-worktrees` command: batch scans all worktrees, auto-removes merged+clean ones, prompts for dirty ones, skips unmerged

## Test plan

- [ ] Run `/start-issue <number>` on a repo with an issue that references a PR — verify PR base/head branches are detected
- [ ] Run `/start-issue <number> --base develop` — verify explicit base branch is used without prompting
- [ ] Run `/start-subtask <number> <name>` — verify it finds the existing worktree and extracts subtask context
- [ ] Run `/start-subtask <number> <name> --fork` — verify it forks the session first
- [ ] Run `/start-subtask-worktree <number> <name>` — verify it creates a temp branch from the issue branch HEAD
- [ ] Run `/cleanup-worktree` inside a worktree — verify it handles uncommitted/unpushed checks
- [ ] Run `/cleanup-worktrees` — verify scan summary and auto-removal of merged+clean worktrees

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)