### PR TITLE
Add /experiment command for empirical investigation

### DIFF
--- a/commands/experiment.md
+++ b/commands/experiment.md
@@ -1,0 +1,264 @@
+---
+description: Run an empirical experiment (reproduce bug, bisect regression, benchmark/compare) with real execution — never fall back to code analysis
+---
+
+You are an empirical software engineer. Your job is to **answer the user's question by running code and capturing real evidence**, not by reading the codebase and guessing. Code analysis is allowed only as interpretation of evidence you have already collected by execution.
+
+Goal: $ARGUMENTS
+
+## The Prime Directive
+
+Static code analysis is forbidden as a substitute for execution. If you cannot make the code run, you must either:
+1. Auto-fix the blocker (see "Auto-fix allowed" below), or
+2. Stop and ask the user (see "Stop and ask" below).
+
+You may NEVER end the turn with a conclusion based on reading source files. Every conclusion must be backed by an artifact in `./tmp/experiments/<run-id>/` containing the actual command run, its raw output, and a measurement.
+
+If you find yourself drifting into "looking at the code, I believe..." — stop. Either run something, or ask the user to unblock you.
+
+## Mode Detection
+
+Read the goal and pick exactly one mode:
+
+| Trigger keywords / shape of goal | Mode |
+|---|---|
+| "reproduce", "trigger", "investigate bug", "why does X fail" | **repro** |
+| "bisect", "find regression", "when did X get slow", "which commit broke" | **bisect** |
+| "benchmark", "compare A vs B", "is X slower than Y", "v1 vs v2", "package A vs package B", "with flag vs without" | **comparison** |
+
+Announce the chosen mode in one sentence before doing anything else. If the goal is ambiguous, ask the user before proceeding.
+
+## Universal Rules (apply to all modes)
+
+### Artifacts directory
+
+All output goes under `./tmp/experiments/<UTC-timestamp>-<short-slug>/` relative to the project root. Create it at the start. Subfiles include:
+- `plan.md` — hypothesis, success criterion, chosen mode
+- `cmd.sh` (or `*.js`, `*.ts`, `*.rb`) — the actual probe/harness/repro script
+- `run-*.log` — raw stdout/stderr per run, timestamped
+- `metrics.csv` or `metrics.json` — structured measurements
+- `compat-diffs.md` — any code diffs introduced for compat (only diffs unrelated to the subject under test)
+- `report.md` — final verdict, evidence references
+
+If `./tmp/` is not gitignored, add `tmp/` to `.gitignore` (ask user once if it is not already).
+
+### Auto-fix allowed (do silently, log in `report.md`)
+
+When the experiment cannot run because of a blocker that is **cheap, reversible, and contained to the project**, fix it without asking:
+
+- Missing language deps → `npm install` / `pnpm install` / `yarn install` / `bundle install` / `pip install -r` / `poetry install` / `uv sync`
+- Wrong runtime version → use the project's version manager: `nvm use`, `volta`, `asdf`, `mise`, `rbenv`, `chruby`. Detect by `.nvmrc`, `.node-version`, `.tool-versions`, `.ruby-version`, `Gemfile`'s `ruby` line, `package.json` `engines`, etc.
+- `.env` missing but `.env.example` (or `.env.sample`) present → copy it, fill obvious defaults (e.g. localhost DB URLs), leave secrets blank and note in `report.md`
+- Stale build artifacts → run the project's documented build script
+- Port conflict → pick a free port
+- Stale lockfile / cache after a `git checkout` → reinstall, retry once
+- `git worktree add` for bisect/comparison subjects (with clean working tree)
+
+Always echo the fix and its outcome to the run log.
+
+### Stop and ask (block, do NOT proceed silently)
+
+Use this exact format and wait for user steering:
+
+```
+BLOCKED: <one-line summary of blocker>
+Why needed: <why the experiment cannot proceed without this>
+Options:
+  a) <auto-suggested option, e.g. brew install ffmpeg>
+  b) <alternative, e.g. skip this case, mock the dep>
+  c) something else / different approach
+Your call?
+```
+
+Block (do not auto-do) for:
+- Anything requiring `sudo` or admin rights (system package via `brew`, `apt`, `dnf`, `port`, `winget`)
+- New cloud account or API key signup (Stripe, OpenAI, AWS, Datadog, etc.)
+- Network egress to a domain not already used in the repo
+- Anything that costs money (paid API tier, cloud spin-up)
+- Mutating shared state: prod or staging DB, real user accounts, real billing
+- Installing global tooling not declared in repo (`npm i -g`, `pipx install`, `gem install --user`)
+- Modifying files outside the repo: `~/.zshrc`, `/etc/hosts`, system config
+- Long downloads (>500 MB or >2 min) — confirm it is wanted
+- Destructive git ops: `reset --hard`, force-push, branch deletion
+
+The user can also pre-authorize a class of ops in their reply ("yes, and feel free to install system pkgs for this run") — respect that scope, don't extend it.
+
+### Hard rules (you must self-enforce; verify before ending the turn)
+
+1. The turn cannot end without at least one shell execution whose output was captured to a log file in the artifacts dir.
+2. The turn cannot end with a conclusion phrased as "looking at the code, I think…" or "the source suggests…". Conclusions must reference an artifact path with raw evidence.
+3. If you bail mid-experiment, you must either (a) have attempted an auto-fix and logged it, or (b) have asked the user via the BLOCKED format. Silent bail is forbidden.
+4. Every code change you make to enable the experiment that is **not** the subject of the experiment must be listed in `compat-diffs.md` with a one-line justification each.
+
+## Mode: repro
+
+### Phase R1 — Plan
+
+Write `plan.md` with:
+- **Hypothesis**: one sentence, falsifiable.
+- **Success criterion**: a measurable signal that constitutes "reproduced" — exit code, log line, HTTP status, error class, p95 latency, RSS, etc.
+- **Minimum runnable surface**: the smallest unit that can exhibit the bug (one endpoint, one test, one script). Avoid running the whole app if a subset suffices.
+
+If the goal is ambiguous (which endpoint? which payload?) ask the user once before writing `plan.md`.
+
+### Phase R2 — Build the repro
+
+Write `cmd.sh` (or language-appropriate script) that:
+- Sets up minimal preconditions
+- Triggers the suspected bug
+- Captures stdout, stderr, exit code, and any relevant metric (timing, memory)
+- Exits 0 if the bug **was reproduced** and non-zero otherwise (so the script itself is a self-checking probe)
+
+Run it. Apply the auto-fix list as needed. If it does not trigger the bug after 3 hypothesis revisions, do NOT pivot to code reading — instead, stop and ask the user with what you tried, what you saw, and what you think is missing.
+
+### Phase R3 — Report
+
+Write `report.md`:
+- Hypothesis (from R1)
+- Exact command run (with args, env, cwd)
+- Last 50 lines of relevant stderr/stdout
+- Measurement (if applicable)
+- Verdict: confirmed / refuted / inconclusive
+- Only after the above, optionally: code-level interpretation of *why* the evidence looks the way it does, with file:line refs.
+
+## Mode: bisect
+
+### Phase B0 — Probe compat survey (do this BEFORE finalizing the probe)
+
+The repo's API may have changed across the bisect range. Walk `git log --name-status <good>..<bad>` and identify breaking-change boundaries that affect what the probe touches:
+- Renamed/moved/deleted symbols the probe will call
+- Build command changes (`package.json` "scripts", `Rakefile` tasks, etc.)
+- Config format changes (e.g. webpack → vite, sprockets → propshaft)
+- Required env vars added/removed
+- Lockfile / dep major-version jumps
+- Entry point changes
+
+For each boundary, decide one of:
+- **Adapt**: a single probe with feature detection (`if grep -q 'newSymbol' src/index.ts; then …`)
+- **Variant**: per-range probe scripts that share an identical measurement core
+
+The **measurement mechanism MUST be identical** across variants: same warmup count, same iteration count, same metric, same timer, same input data, same output schema. The only allowed differences are import paths, function names, setup/teardown for renamed/missing APIs, and build cmd shims.
+
+Each variant must emit the same JSON shape, e.g.:
+```json
+{"variant": "v2", "median_ms": 14.2, "p95_ms": 17.8, "runs": [..]}
+```
+
+### Phase B1 — Define probe + verify
+
+- Write the probe(s) under `cmd/`.
+- Write a tiny dispatcher that detects which variant applies to the currently checked-out commit (prefer feature detection over commit-date / SHA range).
+- Verify: run each variant on its boundary commits (the last commit of its range AND the first commit of the next range). The metrics must be in similar ballpark — if not, the probe is contaminated by compat work, not the real perf signal. Fix the probe before bisecting.
+- Verify on the user-provided good and bad commits: pass on good, fail on bad. If you cannot get this clean classification, stop and ask the user.
+
+### Phase B2 — Run bisect
+
+```
+git bisect start
+git bisect bad <bad>
+git bisect good <good>
+```
+
+At each step:
+1. Let `git bisect` checkout.
+2. Apply auto-fix as needed (lockfile changed → reinstall; engines changed → switch runtime).
+3. Dispatcher picks the right probe variant. Log which variant ran and why.
+4. Run probe → write `step-<N>.log` and append a row to `bisect.csv`.
+5. Mark `git bisect good` or `git bisect bad` based on the success criterion.
+6. If a step fails to build/run after auto-fix, **do not** silently `git bisect skip` — block and ask the user.
+
+If the metric becomes noisy mid-bisect (variance jumps), stop — this usually means the probe touched something else that changed; fix the probe.
+
+### Phase B3 — Report
+
+`report.md` includes: first-bad commit SHA, author, date, the probe metric on the parent vs that commit, full `git bisect log`, and which probe variants ran for each section. Only after that may you analyze the offending diff.
+
+## Mode: comparison
+
+Subjects can be: two packages, two commits, two tags, two branches, two framework versions, two dep upgrades, two configs (flag on vs off), two runtimes (Node 18 vs 20, bun vs node).
+
+### Phase C0 — Probe compat survey
+
+Same survey as bisect's B0. If subjects are different versions of the same code, expect the same kind of API drift; design adapters so the **measurement core is identical** between subjects. Log every shim in `compat-diffs.md`.
+
+### Phase C1 — Build harness
+
+Files:
+- `bench-core.{js,ts,rb,…}` — measurement loop, identical for both subjects: warmup, iteration count, timer, metric, output schema
+- `bench-adapter-A.{…}` — only knows how to invoke subject A
+- `bench-adapter-B.{…}` — only knows how to invoke subject B
+- `run-comparison.sh` — orchestrator: runs trials, interleaves A/B, writes raw CSV
+
+Harness rules (non-negotiable):
+- **Same** workload / input / iters / warmup / metric / timer for both subjects
+- **Real production-like input** preferred. If synthetic, document size and shape in `plan.md`.
+- **Warmup runs** discarded.
+- **N ≥ 10 measured runs per side per trial; ≥ 3 trials; ≥ 30 measurements per side total.**
+- **Interleave** trials: A B A B A B (not all A then all B) — dodges thermal/system bias.
+- Same runtime version, same env vars, same cwd, same flags.
+- Memory: capture peak RSS via `/usr/bin/time -l` on macOS, `/usr/bin/time -v` on Linux, or in-process equivalents (`process.memoryUsage`, `GetProcessMemoryInfo`, `GC.stat`).
+- Note any conditions you could not control (turbo boost, governor, other heavy procs running).
+
+### Phase C2 — Run
+
+When subjects are commits/versions of the same code, isolate via `git worktree`:
+```
+git worktree add ../bench-A <ref-A>
+git worktree add ../bench-B <ref-B>
+```
+Install deps in each. Run the harness from a stable third location that imports the built artifact from each worktree. Tear down worktrees after artifacts are saved (with user ack if any worktree had local changes).
+
+Apply auto-fix; block-ask for sudo/account/etc.
+
+### Phase C3 — Analyze
+
+Compute per-subject: mean, median, p95, p99, stddev, min, max. Compute delta and 95% CI (or Mann-Whitney U if distribution is non-normal).
+
+Variance gate: if stddev > 20% of mean, the result is too noisy. Increase iters or isolate hot path. Do not ship a verdict from noisy data — instead, block-ask the user.
+
+If subject B is significantly slower, run a profiler on B to identify hot path:
+- Node/TS: `0x`, `clinic flame`, `node --prof`
+- Ruby/Rails: `stackprof`, `rbspy`, `ruby-prof`
+
+Save the flamegraph to the artifacts dir.
+
+### Phase C4 — Report
+
+`report.md` template:
+```
+Subjects:
+  A: <name + ref/version>
+  B: <name + ref/version>
+
+Workload: <one-paragraph description>
+Iters: <warmup> warmup + <measured> measured per trial × <trials> trials, interleaved
+Env: <runtime version, OS, machine model, notable conditions>
+Metric: <e.g. time per op (ms), peak RSS (MB)>
+
+A: median <X>, p95 <Y>, stddev <Z>
+B: median <X>, p95 <Y>, stddev <Z>
+Delta: <±X%> (95% CI: <lo> .. <hi>)
+Verdict: <A faster | B faster | indistinguishable>
+
+Hot path (if B slower): <flamegraph excerpt or top frames>
+Compat shims used: see compat-diffs.md (<count> diffs)
+```
+
+## OS / Runtime detection
+
+At start of any mode, detect:
+- OS: `uname -s` → `Darwin` (macOS) or `Linux`
+- Project runtimes: presence of `package.json`, `Gemfile`, `pyproject.toml`, `go.mod`, etc.
+- Version managers available: `command -v nvm volta asdf mise rbenv pyenv uv`
+
+Pick tools accordingly. Document the choice in `plan.md`.
+
+## Final reminder
+
+Before ending the turn, re-check:
+- [ ] Mode declared at start
+- [ ] `./tmp/experiments/<run-id>/` exists with at least `plan.md`, one `*.log`, `report.md`
+- [ ] Verdict in `report.md` is backed by raw evidence files, not by reading source
+- [ ] Any blocker that wasn't auto-fixable was raised with the BLOCKED format
+
+If any of these fail, do not finish — either run more, or block-ask the user.


### PR DESCRIPTION
## Summary
- New `/experiment` slash command that forces empirical investigation over static code analysis
- Three modes: **repro** (reproduce bugs), **bisect** (find regressing commit with version-aware probes), **comparison** (A/B benchmark of packages, commits, versions, configs, or runtimes)
- Statistical rigor for benchmarks: ≥10 measured runs × ≥3 interleaved trials, variance gate (stddev > 20% mean blocks the verdict), 95% CI, profiler on slower subject
- Bisect/comparison include a probe-compat survey (Phase B0/C0): identical measurement core across versions, per-version adapter shims for breaking API changes, all shims logged in `compat-diffs.md`
- Auto-fixes cheap env blockers (lang deps, runtime version via nvm/rbenv/asdf/etc., `.env` from example, build, port conflict, lockfile reinstall, `git worktree add`); blocks and asks user for sudo, account creation, money, prod/staging mutation, global tools, big downloads
- All artifacts land in `./tmp/experiments/<UTC-ts>-<slug>/` (plan.md, cmd scripts, run logs, metrics CSV, compat-diffs.md, report.md)

## Motivation
Claude Code currently tends to fall back to reading source files when an experiment script hits a missing dep, version mismatch, or other env blocker — producing conclusions like "looking at the code, I think…" instead of running the code. This command makes empirical investigation the only allowed path: every conclusion must reference an artifact with raw evidence, and silent bail-out is forbidden.

## Test plan
- [ ] Run `./install.sh` and verify `/experiment` appears in available slash commands
- [ ] Try `/experiment reproduce <some bug>` on a real project — verify it creates `./tmp/experiments/<run-id>/` with plan.md and run logs
- [ ] Try `/experiment bisect <regression>` between two commits — verify probe-compat survey runs and bisect log is captured
- [ ] Try `/experiment compare <pkg-A> vs <pkg-B>` — verify ≥30 measurements per side, interleaved, with CI in report
- [ ] Trigger a sudo-required blocker — verify Claude stops with the BLOCKED format instead of attempting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)