### PR TITLE
Add /keep-going command for accidental interrupts

### DIFF
--- a/commands/keep-going.md
+++ b/commands/keep-going.md
@@ -1,0 +1,9 @@
+---
+description: Previous interrupt was accidental — resume prior work without second-guessing
+---
+
+User hit ESC, lost power, or otherwise stopped you by accident. Not disapproval. Don't apologize, don't switch approach, don't ask permission to continue.
+
+Scan back, find the last in-progress step (tool call, todo, plan), state in one short sentence what you're resuming, then resume. If a tool call was interrupted mid-flight, re-issue it (verify partial state first if it was destructive).
+
+If genuinely nothing to resume, say so and ask what's next.


### PR DESCRIPTION
## Summary
- Adds `/keep-going` slash command that tells Claude an interrupt (ESC, device shutdown, network drop) was accidental — resume the prior plan without apologizing or switching approach.

## Test plan
- [ ] Run `./install.sh` on a fresh clone — symlink lands at `~/.claude/commands/keep-going.md`
- [ ] Invoke `/keep-going` mid-session after pressing ESC; verify Claude resumes the last in-progress step instead of asking for clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)