### PR TITLE
Add issue session tracker and model launcher commands

### DIFF
--- a/bin/claude-middle
+++ b/bin/claude-middle
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Launch Claude with Opus 4.6 model (middle version)
+# Usage: claude-middle [--safe] [claude args...]
+#
+# --safe: Run without --dangerously-skip-permissions
+
+set -euo pipefail
+
+SKIP_PERMS="--dangerously-skip-permissions"
+MODEL="--model claude-opus-4-6"
+ARGS=()
+
+for arg in "$@"; do
+  if [[ "$arg" == "--safe" ]]; then
+    SKIP_PERMS=""
+  else
+    ARGS+=("$arg")
+  fi
+done
+
+# shellcheck disable=SC2086
+exec claude $SKIP_PERMS $MODEL "${ARGS[@]}"

--- a/bin/claude-middle
+++ b/bin/claude-middle
@@ -20,4 +20,4 @@ for arg in "$@"; do
 done
 
 # shellcheck disable=SC2086
-exec claude $SKIP_PERMS $MODEL "${ARGS[@]}"
+exec claude $SKIP_PERMS $MODEL ${ARGS[@]+"${ARGS[@]}"}

--- a/bin/claude-oldest
+++ b/bin/claude-oldest
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Launch Claude with Opus 4.5 model (oldest supported)
+# Usage: claude-oldest [--safe] [claude args...]
+#
+# --safe: Run without --dangerously-skip-permissions
+
+set -euo pipefail
+
+SKIP_PERMS="--dangerously-skip-permissions"
+MODEL="--model claude-opus-4-5-20251101"
+ARGS=()
+
+for arg in "$@"; do
+  if [[ "$arg" == "--safe" ]]; then
+    SKIP_PERMS=""
+  else
+    ARGS+=("$arg")
+  fi
+done
+
+# shellcheck disable=SC2086
+exec claude $SKIP_PERMS $MODEL "${ARGS[@]}"

--- a/bin/claude-oldest
+++ b/bin/claude-oldest
@@ -20,4 +20,4 @@ for arg in "$@"; do
 done
 
 # shellcheck disable=SC2086
-exec claude $SKIP_PERMS $MODEL "${ARGS[@]}"
+exec claude $SKIP_PERMS $MODEL ${ARGS[@]+"${ARGS[@]}"}

--- a/bin/claude-sota
+++ b/bin/claude-sota
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Launch Claude with default (state-of-the-art) model
+# Usage: claude-sota [--safe] [claude args...]
+#
+# --safe: Run without --dangerously-skip-permissions
+
+set -euo pipefail
+
+SKIP_PERMS="--dangerously-skip-permissions"
+ARGS=()
+
+for arg in "$@"; do
+  if [[ "$arg" == "--safe" ]]; then
+    SKIP_PERMS=""
+  else
+    ARGS+=("$arg")
+  fi
+done
+
+# shellcheck disable=SC2086
+exec claude $SKIP_PERMS "${ARGS[@]}"

--- a/bin/claude-sota
+++ b/bin/claude-sota
@@ -19,4 +19,4 @@ for arg in "$@"; do
 done
 
 # shellcheck disable=SC2086
-exec claude $SKIP_PERMS "${ARGS[@]}"
+exec claude $SKIP_PERMS ${ARGS[@]+"${ARGS[@]}"}

--- a/commands/track-issue.md
+++ b/commands/track-issue.md
@@ -1,0 +1,166 @@
+---
+description: Link current session to a GitHub issue for tracking work across sessions
+---
+
+Track work done in this Claude Code session against a GitHub issue. Creates a log file at `~/.claude/issues/` so you can find related sessions later.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse arguments to extract issue reference:
+- `owner/repo#123` — full issue reference
+- `#123` or `123` — issue number (uses current repo)
+- `https://github.com/owner/repo/issues/123` — full URL
+
+Extract owner, repo, and issue number. If only number provided, detect current repo:
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+```
+
+## Workflow
+
+### 1. Validate and fetch issue
+
+```bash
+gh issue view <NUMBER> --repo <OWNER>/<REPO> --json number,title,state
+```
+
+If issue doesn't exist or is inaccessible, report error and stop.
+
+### 2. Check for existing tracking
+
+Read the current session's tracked issues from environment or session state.
+
+If already tracking other issues in this session:
+1. List currently tracked issues
+2. Ask user: "Already tracking [issues]. Add this issue too? (Sessions will be cross-referenced in both files)"
+3. If user declines, stop without changes
+
+### 3. Set up tracking file
+
+Create directory if needed:
+```bash
+mkdir -p ~/.claude/issues
+```
+
+File path: `~/.claude/issues/<owner>-<repo>-<number>.md`
+
+### 4. Add session entry
+
+Get current session info:
+- Session ID: Use `$CLAUDE_SESSION_ID` environment variable or generate unique ID
+- Timestamp: Current date/time
+- Branch: `git branch --show-current`
+- Initial description: "Session started — tracking issue #<number>"
+
+If file exists, append new session entry. If not, create with header.
+
+Also save the session-to-issue mapping for fork tracking:
+```bash
+mkdir -p ~/.claude/session-issues
+echo "<owner>-<repo>-<number>" >> ~/.claude/session-issues/$CLAUDE_SESSION_ID
+```
+
+**File format:**
+```markdown
+# <owner>/<repo>#<number>: <issue-title>
+
+Issue: https://github.com/<owner>/<repo>/issues/<number>
+
+---
+
+## Session: <session-id>
+**Started:** <timestamp>
+**Branch:** <branch-name>
+**Commits:** (none yet)
+
+### Work Log
+- Session started — tracking issue #<number>
+
+---
+```
+
+### 5. Cross-reference if multi-issue
+
+If tracking multiple issues in this session, add a note to ALL tracked issue files:
+
+```markdown
+> **Note:** This session also worked on: owner/repo#X, owner/repo#Y
+```
+
+### 6. Confirm to user
+
+Display:
+- Issue: #<number> — <title>
+- Tracking file: ~/.claude/issues/<owner>-<repo>-<number>.md
+- Session ID: <id>
+- Other tracked issues (if any)
+
+Tell user: "I'll update the work log when we hit milestones (commits, plans, major findings). You can also ask me to update it anytime."
+
+## Milestone Updates
+
+Throughout the session, when the following occur, update the session's Work Log:
+
+1. **After commits**: Add commit hash and one-line summary
+2. **After finalizing a plan**: Add "Planned: <brief description>"
+3. **After major investigation findings**: Add "Found: <brief description>"
+4. **When user explicitly asks**: Update with whatever context is relevant
+
+To update, read the tracking file, find the current session section, append to Work Log, write back.
+
+**Update format:**
+```markdown
+- [<timestamp>] <type>: <description>
+```
+
+Example:
+```markdown
+### Work Log
+- Session started — tracking issue #42
+- [14:30] Commit: abc1234 - Fix null check in auth handler
+- [14:45] Found: Bug caused by race condition in token refresh
+- [15:00] Planned: Add mutex lock before token access
+- [15:20] Commit: def5678 - Add mutex lock to prevent race condition
+```
+
+## Session End
+
+When session ends or user switches to different work, add final entry:
+```markdown
+- [<timestamp>] Session ended
+```
+
+## Session Fork Tracking
+
+To automatically track forked sessions, add this hook to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/track-issue-resume.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+When a session is forked/resumed, the hook reads which issues the parent session was tracking and adds the new session to those issue files automatically.
+
+## Important Notes
+
+- Always use absolute paths for the tracking file
+- Preserve existing content when updating — only append or modify current session section
+- If git commands fail (not in repo), still track but note "Branch: (not in git repo)"
+- Session ID should be consistent if user runs /track-issue multiple times in same session
+- Session-to-issue mappings stored at `~/.claude/session-issues/<session-id>`

--- a/commands/track-issue.md
+++ b/commands/track-issue.md
@@ -49,7 +49,7 @@ File path: `~/.claude/issues/<owner>-<repo>-<number>.md`
 ### 4. Add session entry
 
 Get current session info:
-- Session ID: Use `$CLAUDE_SESSION_ID` environment variable or generate unique ID
+- Session ID: Use `$CLAUDE_CODE_SESSION_ID` environment variable or generate unique ID
 - Timestamp: Current date/time
 - Branch: `git branch --show-current`
 - Initial description: "Session started — tracking issue #<number>"
@@ -59,7 +59,7 @@ If file exists, append new session entry. If not, create with header.
 Also save the session-to-issue mapping for fork tracking:
 ```bash
 mkdir -p ~/.claude/session-issues
-echo "<owner>-<repo>-<number>" >> ~/.claude/session-issues/$CLAUDE_SESSION_ID
+echo "<owner>-<repo>-<number>" >> ~/.claude/session-issues/$CLAUDE_CODE_SESSION_ID
 ```
 
 **File format:**

--- a/commands/track-issue.md
+++ b/commands/track-issue.md
@@ -109,7 +109,8 @@ Throughout the session, update the Work Log **only for significant events** — 
 3. **Workarounds/patches**: Temporary fixes for critical issues (even in external libraries/frameworks we maintain)
 4. **Major investigation findings**: Root cause discovered, unexpected behavior explained
 5. **Plans finalized**: Architecture decisions, implementation strategy agreed
-6. **User explicitly asks**: Whatever context they want recorded
+6. **PRs opened**: When creating a PR, log PR number and URL
+7. **User explicitly asks**: Whatever context they want recorded
 
 **What NOT to log:**
 - Routine commits (typo fixes, small adjustments, incremental progress)
@@ -131,6 +132,7 @@ Example:
 - [15:00] Planned: Add mutex lock + token versioning to handle concurrent refreshes
 - [15:20] Fixed: abc1234 - Took 2h to trace; symptom was intermittent 401s only under load
 - [16:00] Workaround: Patched redis-client@3.2.1 connection pooling bug (upstream PR pending)
+- [16:30] PR: #156 https://github.com/owner/repo/pull/156
 ```
 
 ## Session End

--- a/commands/track-issue.md
+++ b/commands/track-issue.md
@@ -97,16 +97,24 @@ Display:
 - Session ID: <id>
 - Other tracked issues (if any)
 
-Tell user: "I'll update the work log when we hit milestones (commits, plans, major findings). You can also ask me to update it anytime."
+Tell user: "I'll update the work log for significant events only — milestones, hard-won fixes, workarounds, major findings. Not routine commits. Ask me anytime to log something specific."
 
 ## Milestone Updates
 
-Throughout the session, when the following occur, update the session's Work Log:
+Throughout the session, update the Work Log **only for significant events** — not routine commits.
 
-1. **After commits**: Add commit hash and one-line summary
-2. **After finalizing a plan**: Add "Planned: <brief description>"
-3. **After major investigation findings**: Add "Found: <brief description>"
-4. **When user explicitly asks**: Update with whatever context is relevant
+**What to log:**
+1. **Milestones**: Major feature complete, significant refactor done, important decision made
+2. **Hard-won fixes**: Bugs that took significant debugging time to solve
+3. **Workarounds/patches**: Temporary fixes for critical issues (even in external libraries/frameworks we maintain)
+4. **Major investigation findings**: Root cause discovered, unexpected behavior explained
+5. **Plans finalized**: Architecture decisions, implementation strategy agreed
+6. **User explicitly asks**: Whatever context they want recorded
+
+**What NOT to log:**
+- Routine commits (typo fixes, small adjustments, incremental progress)
+- Standard implementation steps
+- Every file change
 
 To update, read the tracking file, find the current session section, append to Work Log, write back.
 
@@ -119,10 +127,10 @@ Example:
 ```markdown
 ### Work Log
 - Session started — tracking issue #42
-- [14:30] Commit: abc1234 - Fix null check in auth handler
-- [14:45] Found: Bug caused by race condition in token refresh
-- [15:00] Planned: Add mutex lock before token access
-- [15:20] Commit: def5678 - Add mutex lock to prevent race condition
+- [14:45] Found: Race condition in token refresh — tokens invalidated mid-request when concurrent refresh triggered
+- [15:00] Planned: Add mutex lock + token versioning to handle concurrent refreshes
+- [15:20] Fixed: abc1234 - Took 2h to trace; symptom was intermittent 401s only under load
+- [16:00] Workaround: Patched redis-client@3.2.1 connection pooling bug (upstream PR pending)
 ```
 
 ## Session End

--- a/commands/track-issue.md
+++ b/commands/track-issue.md
@@ -140,20 +140,54 @@ When session ends or user switches to different work, add final entry:
 - [<timestamp>] Session ended
 ```
 
-## Session Fork Tracking
+## Session Branch/Fork Tracking
 
-To automatically track forked sessions, add this hook to `~/.claude/settings.json`:
+When a session is branched via `/branch`, the parent session's issue tracking should carry over to the new session.
+
+### How it works
+
+1. A `UserPromptSubmit` hook detects `/branch` commands
+2. If parent session was tracking issues, hook injects marker: `<branch-tracking-inherit parent="..." issues="..."/>`
+3. Branched session inherits this marker in conversation context
+4. Claude detects marker and registers new session
+
+### Handling the marker
+
+**On EVERY response**, check conversation context for `<branch-tracking-inherit>` marker. If found AND current session not yet registered:
+
+1. Parse parent session ID and issues list from marker
+2. Create session-issues mapping:
+   ```bash
+   mkdir -p ~/.claude/session-issues
+   echo "<issues>" | tr ',' '\n' > ~/.claude/session-issues/$CLAUDE_CODE_SESSION_ID
+   ```
+3. Append to each issue's tracking file:
+   ```markdown
+   ---
+
+   ## Session: <current-session-id> (branched from <parent-session-id>)
+   **Started:** <timestamp>
+   **Branch:** <branch-name>
+   **Commits:** (none yet)
+
+   ### Work Log
+   - Session branched from <parent-session-id>
+   ```
+4. Do this silently — don't mention it to user unless asked
+
+### Hook setup
+
+Add to `~/.claude/settings.json`:
 
 ```json
 {
   "hooks": {
-    "SessionStart": [
+    "UserPromptSubmit": [
       {
-        "matcher": "resume",
         "hooks": [
           {
             "type": "command",
-            "command": "bash ~/.claude/hooks/track-issue-resume.sh",
+            "command": "bash ~/.claude/hooks/track-issue-branch.sh",
             "timeout": 5
           }
         ]
@@ -162,8 +196,6 @@ To automatically track forked sessions, add this hook to `~/.claude/settings.jso
   }
 }
 ```
-
-When a session is forked/resumed, the hook reads which issues the parent session was tracking and adds the new session to those issue files automatically.
 
 ## Important Notes
 

--- a/hooks/track-issue-branch.sh
+++ b/hooks/track-issue-branch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Hook: Inject tracking marker when /branch command detected
+# Fires on UserPromptSubmit, checks for /branch pattern
+#
+# If current session is tracking issues, injects marker into conversation
+# so the branched session inherits it and Claude can update tracking.
+
+set -euo pipefail
+
+SESSION_ISSUES_DIR="$HOME/.claude/session-issues"
+
+# Parse input
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+# Check if this is a /branch command
+if [[ ! "$PROMPT" =~ ^/branch ]]; then
+  exit 0
+fi
+
+# Check if current session is tracking any issues
+if [[ -z "$SESSION_ID" ]] || [[ ! -f "$SESSION_ISSUES_DIR/$SESSION_ID" ]]; then
+  exit 0
+fi
+
+# Read tracked issues
+TRACKED_ISSUES=$(cat "$SESSION_ISSUES_DIR/$SESSION_ID" | tr '\n' ',' | sed 's/,$//')
+
+if [[ -z "$TRACKED_ISSUES" ]]; then
+  exit 0
+fi
+
+# Inject marker into conversation
+jq -n --arg parent "$SESSION_ID" --arg issues "$TRACKED_ISSUES" '{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "<branch-tracking-inherit parent=\"\($parent)\" issues=\"\($issues)\"/>"
+  }
+}'
+
+exit 0

--- a/hooks/track-issue-resume.sh
+++ b/hooks/track-issue-resume.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Hook: Add resumed session to issue tracking files
+# Fires on SessionStart when session is resumed (includes forks)
+#
+# Input (JSON via stdin):
+#   session_id, transcript_path, cwd, etc.
+#
+# Reads tracked issues from ~/.claude/session-issues/<old-session-id>
+# and adds new session entry to each issue's tracking file.
+
+set -euo pipefail
+
+ISSUES_DIR="$HOME/.claude/issues"
+SESSION_ISSUES_DIR="$HOME/.claude/session-issues"
+
+# Parse input
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+
+if [[ -z "$SESSION_ID" ]]; then
+  exit 0
+fi
+
+# Try to find parent session from transcript path
+# Format: ~/.claude/sessions/<session-id>/transcript.json
+if [[ -n "$TRANSCRIPT_PATH" && "$TRANSCRIPT_PATH" =~ sessions/([^/]+)/ ]]; then
+  PARENT_SESSION="${BASH_REMATCH[1]}"
+else
+  exit 0
+fi
+
+# Check if parent session was tracking any issues
+PARENT_ISSUES_FILE="$SESSION_ISSUES_DIR/$PARENT_SESSION"
+if [[ ! -f "$PARENT_ISSUES_FILE" ]]; then
+  exit 0
+fi
+
+# Read tracked issues from parent
+TRACKED_ISSUES=$(cat "$PARENT_ISSUES_FILE")
+if [[ -z "$TRACKED_ISSUES" ]]; then
+  exit 0
+fi
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M')
+BRANCH=$(git branch --show-current 2>/dev/null || echo "(not in git repo)")
+
+# Copy issue tracking to new session
+mkdir -p "$SESSION_ISSUES_DIR"
+echo "$TRACKED_ISSUES" > "$SESSION_ISSUES_DIR/$SESSION_ID"
+
+# Add new session entry to each issue's tracking file
+while IFS= read -r issue_ref; do
+  [[ -z "$issue_ref" ]] && continue
+
+  # issue_ref format: owner-repo-number
+  ISSUE_FILE="$ISSUES_DIR/$issue_ref.md"
+
+  if [[ -f "$ISSUE_FILE" ]]; then
+    # Add new session section
+    cat >> "$ISSUE_FILE" << EOF
+
+---
+
+## Session: $SESSION_ID (forked from $PARENT_SESSION)
+**Started:** $TIMESTAMP
+**Branch:** $BRANCH
+**Commits:** (none yet)
+
+### Work Log
+- Session forked from $PARENT_SESSION
+
+EOF
+  fi
+done <<< "$TRACKED_ISSUES"

--- a/install.sh
+++ b/install.sh
@@ -44,5 +44,40 @@ for file in "$REPO_DIR"/commands/*.md; do
   link_file "$file" "$CLAUDE_DIR/commands/$basename"
 done
 
+# Link shell helper scripts (codex-loop-helper.sh etc)
+for file in "$REPO_DIR"/commands/*.sh; do
+  [ -f "$file" ] || continue
+  basename="$(basename "$file")"
+  link_file "$file" "$CLAUDE_DIR/commands/$basename"
+done
+
+# Link bin scripts to ~/.local/bin for PATH access
+LOCAL_BIN="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN"
+for file in "$REPO_DIR"/bin/*; do
+  [ -f "$file" ] || continue
+  basename="$(basename "$file")"
+  link_file "$file" "$LOCAL_BIN/$basename"
+done
+
+# Link hook scripts
+mkdir -p "$CLAUDE_DIR/hooks"
+for file in "$REPO_DIR"/hooks/*.sh; do
+  [ -f "$file" ] || continue
+  basename="$(basename "$file")"
+  link_file "$file" "$CLAUDE_DIR/hooks/$basename"
+done
+
+# Create directories for issue tracking
+mkdir -p "$CLAUDE_DIR/issues"
+mkdir -p "$CLAUDE_DIR/session-issues"
+
 echo
 echo "Done! Claude customizations are now symlinked from this repo."
+echo
+echo "Notes:"
+echo "  - Make sure ~/.local/bin is in your PATH for claude-oldest, claude-middle, claude-sota commands."
+echo "    Add to shell config: export PATH=\"\$HOME/.local/bin:\$PATH\""
+echo
+echo "  - To enable session fork tracking for /track-issue, add to ~/.claude/settings.json:"
+echo '    "hooks": { "SessionStart": [{ "matcher": "resume", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/track-issue-resume.sh", "timeout": 5 }] }] }'


### PR DESCRIPTION
## Summary

- Add `/track-issue` command to link Claude sessions to GitHub issues for cross-session tracking
- Add model launcher commands (`claude-oldest`, `claude-middle`, `claude-sota`) for quick Claude launches with specific models
- Add session fork hook to automatically track forked sessions

## Feature 1: Issue Session Tracker

**Usage:** `/track-issue owner/repo#123` or `/track-issue <github-url>`

- Creates/updates markdown files at `~/.claude/issues/`
- Tracks: session ID, timestamp, branch, commits, work log
- Updates on milestones (commits, plans, findings)
- Multi-issue support with cross-references
- Session fork tracking via `SessionStart` hook

## Feature 2: Model Launcher Commands

| Command | Model | Flags |
|---------|-------|-------|
| `claude-oldest` | claude-opus-4-5-20251101 | --dangerously-skip-permissions |
| `claude-middle` | claude-opus-4-6 | --dangerously-skip-permissions |
| `claude-sota` | (default) | --dangerously-skip-permissions |

- Pass `--safe` to disable skip-permissions
- All other args passed through to Claude

## Test plan

- [ ] Run `./install.sh` and verify symlinks created
- [ ] Test `/track-issue` creates file at `~/.claude/issues/`
- [ ] Test `claude-oldest`, `claude-middle`, `claude-sota` launch Claude correctly
- [ ] Test `--safe` flag disables skip-permissions
- [ ] Verify hook setup instructions in install.sh output

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)