### PR TITLE
Add /list-issues and /issue-sessions commands (closes #17)

### DIFF
--- a/commands/issue-sessions.md
+++ b/commands/issue-sessions.md
@@ -1,0 +1,100 @@
+---
+description: Show every session recorded for one tracked issue, with branch, worktree, and Work Log per session
+---
+
+Render a session-by-session view of one issue's tracking file. Read-only; never edits.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Accept any of:
+
+- `<owner>/<repo>#<num>` — full issue reference
+- `#<num>` or `<num>` — issue number (uses current repo, detected via `gh repo view --json nameWithOwner`)
+- `https://github.com/<owner>/<repo>/issues/<num>` — full URL
+
+If only a number is given but the cwd is not inside a git repo (or `gh` cannot resolve it), ask the user to provide the full `<owner>/<repo>#<num>` form and stop.
+
+## Workflow
+
+### 1. Resolve to a tracking file
+
+Construct path: `~/.claude/issues/<owner>-<repo>-<num>.md`.
+
+If the file does not exist:
+
+- Tell the user: "No tracking file for `<owner>/<repo>#<num>`."
+- Suggest: "Run `/track-issue <ref>` to start tracking, or `/list-issues` to see what is tracked."
+- Stop.
+
+### 2. Fetch current GitHub state (best-effort)
+
+```bash
+gh issue view <num> --repo <owner>/<repo> --json state,title -q '"\(.state) \(.title)"'
+```
+
+If this fails (offline, auth error, deleted issue), continue without state — show `?` in the header and proceed using only on-disk data.
+
+### 3. Parse the tracking file
+
+Read the file. Extract:
+
+- **Header**: `# <owner>/<repo>#<num>: <title>` and the `Issue:` URL line.
+- **Sessions**: every `## Session:` block. For each:
+  - **Session ID** from the heading; note any parenthesized origin like `(forked from ...)` or `(branched from ...)`.
+  - **Started** (`**Started:**` value)
+  - **Branch** (`**Branch:**` value)
+  - **Worktree** (`**Worktree:**` value if present, else `(unknown)`)
+  - **Commits** (`**Commits:**` line if present, else `(none yet)`)
+  - **Work Log entries** — every bullet under the session's `### Work Log` heading, until the next `---` or `## Session:` boundary.
+
+A session block ends at the next `---` divider, the next `## Session:` heading, or end-of-file — whichever comes first.
+
+### 4. Render output
+
+Print, in order:
+
+```
+<owner>/<repo>#<num>: <title> [<state>]
+Issue: <url>
+Tracking file: ~/.claude/issues/<owner>-<repo>-<num>.md
+
+<N> session(s):
+```
+
+Then, for each session, sorted by `**Started:**` ascending (oldest first):
+
+```
+[<index>] <session-id-short> — <Started> <origin>
+        Branch:   <branch>
+        Worktree: <worktree>
+        Commits:  <commits>
+        Work log:
+          - Session started — tracking issue #<num>
+          - [14:45] Found: ...
+          - [16:30] PR: #156 https://...
+```
+
+Format notes:
+
+- `<session-id-short>` = first 8 chars of the session ID, a visual aid only — print the full ID once at the top of the block: `[<index>] Session <full-id>`.
+- `<origin>` = `(forked from <short-parent>)` or `(branched from <short-parent>)` if applicable, else empty.
+- Indent Work Log entries under their session for readability.
+- If the Work Log is empty, print `Work log: (empty)`.
+
+### 5. Footer
+
+After the last session:
+
+- If the issue is closed and the most recent Work Log entry doesn't include `Session ended`, note this is open-ended.
+- Suggest `/list-issues` if the user wants to find related issues. One short line.
+
+## Important Notes
+
+- **Read-only.** Never modify the tracking file.
+- **Display fidelity**: render Work Log entries verbatim. Do not paraphrase or merge.
+- **Long Work Logs**: if a session has more than ~30 entries, render all of them anyway — truncation hides the value of this command. The user asked for sessions; show them.
+- **Cross-session ordering**: oldest session first by default. The user can scroll up to see history; the most recent session is at the bottom and visually closest to the prompt.
+- **Forks/branches**: when a session has a parent, print the parent's short ID inline so the lineage is clear without forcing the reader to scan IDs.
+- **Time zones**: timestamps are rendered as written in the file. No conversion.

--- a/commands/list-issues.md
+++ b/commands/list-issues.md
@@ -1,0 +1,103 @@
+---
+description: List GitHub issues this machine has tracking files for, with filters by activity date, state, and recency
+---
+
+Walk `~/.claude/issues/` and produce a table of every tracked issue, optionally filtered by recency or state. Reads tracking files only — no writes.
+
+Arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Single filter flag, plus optional `--repo <owner>/<repo>` to narrow to one repository. Filters are mutually exclusive — if more than one is supplied, ask the user which they want and stop.
+
+| Flag | Meaning |
+|------|---------|
+| (none) | All tracked issues |
+| `--active` | At least one session within the last 7 days |
+| `--completed` | The GitHub issue is closed (state=CLOSED) |
+| `--today` | At least one session whose `**Started:**` date is today |
+| `--yesterday` | At least one session whose `**Started:**` date is yesterday |
+| `--since <YYYY-MM-DD>` | At least one session on or after the given date |
+| `--period <START> <END>` | At least one session whose date falls in `[START, END]` inclusive (both `YYYY-MM-DD`) |
+| `--repo <owner>/<repo>` | Restrict to one repo. Combinable with any of the above. |
+
+If a date is malformed, surface a clear error and stop.
+
+## Workflow
+
+### 1. Enumerate tracking files
+
+```bash
+ls ~/.claude/issues/*.md 2>/dev/null
+```
+
+If there are no files, tell the user "No tracked issues on this machine." and stop.
+
+If `--repo <owner>/<repo>` is set, restrict to files whose names start with `<owner>-<repo>-`.
+
+### 2. Parse each file
+
+For each file, extract:
+
+- **Issue ref**: from the filename (`<owner>-<repo>-<num>.md` → `<owner>/<repo>#<num>`)
+- **Title**: from the first `# ` heading line (strip the `<owner>/<repo>#<num>: ` prefix)
+- **Issue URL**: from the `Issue:` line in the header
+- **Sessions**: every `## Session:` block. For each, capture the `**Started:**` value as a timestamp.
+- **Last session date**: the most recent session's `**Started:**` date (`YYYY-MM-DD`).
+- **Session count**: total number of `## Session:` blocks in the file.
+
+If a file has zero sessions or is malformed, include it in output but mark `last: (none)` and `0 sessions`.
+
+### 3. Apply the filter
+
+#### Activity-based filters (`--active`, `--today`, `--yesterday`, `--since`, `--period`)
+
+These filter on session-start dates. Compute today's date once; derive yesterday and the 7-day window from it. An issue passes the filter if **any** of its session timestamps satisfies the rule.
+
+#### State-based filters (`--completed`)
+
+For each candidate file, fetch state from GitHub:
+
+```bash
+gh issue view <num> --repo <owner>/<repo> --json state -q .state
+```
+
+Run these in parallel (background subshells) when there are many files, to avoid serial latency. If `gh` fails (network, auth, deleted issue), mark state as `?` and exclude from `--completed` results (do not falsely include).
+
+#### `--active`
+
+A passing issue must satisfy **both**: session within the last 7 days AND state is `OPEN`. Closed issues with recent activity are excluded — `--completed` is the right filter for those.
+
+### 4. Render output
+
+Sort the resulting issues by **most recent session date, descending**. Issues with no sessions go last.
+
+For each row print:
+
+```
+#<num>  <owner>/<repo>   <state>   <N> session<s>   last: <YYYY-MM-DD>   <title>
+```
+
+- `<state>` is `open`, `closed`, or `?` if unfetched.
+- Truncate `<title>` to keep the row readable (~80 chars total before title).
+- Use a fixed-width layout — the human will paste this into a terminal.
+
+Add a one-line header summarizing the filter:
+
+```
+Tracked issues (filter: --active, repo: AbanoubGhadban/my-claude) — N matches
+```
+
+If zero matches, say so and exit cleanly.
+
+### 5. After-output hint
+
+If the user wants to drill into one of these, suggest `/issue-sessions <ref>` for a session-by-session breakdown. One short line, only when there are matches.
+
+## Important Notes
+
+- **Read-only.** Never modify a tracking file.
+- **No `gh` calls unless required by the active filter** (i.e. only fetch state when `--active` or `--completed` is set, or when state is part of the requested output for some other reason). Default listing shows state as `?` to avoid burning API quota on a routine ls-style command.
+- **Time zone**: all date arithmetic uses the local machine's clock. Sessions are assumed to be in the same local time as the user invoking the command.
+- **Missing fields tolerated**: a tracking file written before the format included a particular field still parses — just leave the field unknown.
+- **Do not fabricate session counts**: if parsing is ambiguous, prefer reporting `?` over guessing.


### PR DESCRIPTION
## Summary

Implements the remaining two features from #17. Worktree integration shipped earlier in #18.

- **`/list-issues`** — walks `~/.claude/issues/`, parses every tracking file, prints a fixed-width table sorted by most-recent-session-first. Filters: `--today`, `--yesterday`, `--since <date>`, `--period <start> <end>`, `--active` (open + activity in last 7 days), `--completed` (closed on GitHub). `--repo <owner>/<repo>` narrows to one repository. State is fetched via `gh` only when the active filter requires it, to avoid burning API quota on default listings. Read-only.
- **`/issue-sessions`** — takes one issue reference (`owner/repo#N`, `#N`, `N`, or a GitHub URL) and renders the matching tracking file as a session-by-session breakdown: Session ID, Started, Branch, Worktree, Commits, and the full Work Log per session, oldest first. Forked and branched sessions display their parent short ID inline. Read-only.

Both commands tolerate legacy session blocks missing the `**Worktree:**` field (renders as `(unknown)`) so existing tracking files keep working.

## Test plan

- [ ] `/list-issues` with no filter → shows every tracked issue, sorted by recency
- [ ] `/list-issues --today` / `--yesterday` → only matching dates
- [ ] `/list-issues --since 2026-05-01` and `/list-issues --period 2026-05-01 2026-05-09` → date-window filtering
- [ ] `/list-issues --active` → open issues with activity in last 7 days; closed-but-recent are excluded
- [ ] `/list-issues --completed` → only GitHub-closed issues
- [ ] `/list-issues --repo AbanoubGhadban/my-claude` → narrows to one repo
- [ ] Two filters at once (e.g. `--active --completed`) → command asks user to pick one
- [ ] `/issue-sessions 17` and `/issue-sessions AbanoubGhadban/my-claude#17` → identical output
- [ ] `/issue-sessions <bogus-ref>` → friendly "no tracking file" message + suggests `/track-issue`
- [ ] `/issue-sessions` for a forked/branched session → parent short ID shown inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)