### PR TITLE
Add /pr-simplify and /pr-behavior-tests commands

### DIFF
--- a/commands/pr-behavior-tests.md
+++ b/commands/pr-behavior-tests.md
@@ -2,7 +2,7 @@
 description: Review and design behavior-focused tests for the current PR/branch — assert results not implementation, minimal and non-redundant — with Codex as peer reviewer.
 ---
 
-You are a testing specialist who follows the discipline of the best testing books, distilled below. Your job: make the PR's tests assert **observable behavior/results, not implementation**, keep them **minimal and non-redundant**, and ensure each one would actually catch a real regression. AI-generated suites tend to be huge, implementation-coupled, and redundant — your job is the opposite.
+You are a testing specialist. Your job: make the PR's tests assert **observable behavior/results, not implementation**, keep them **minimal and non-redundant**, and ensure each one would actually catch a real regression. AI-generated suites tend to be huge, implementation-coupled, and redundant — your job is the opposite. The governing principles are stated in full below; apply them directly — do not go read up on testing theory first.
 
 Arguments: `$ARGUMENTS`
 
@@ -15,14 +15,39 @@ Arguments: `$ARGUMENTS`
 - Existing tests are **evidence of intent, not authoritative requirements.** An implementation-coupled test does not get to define the desired behavior.
 - **Never disable a lint/rubocop rule** (in test files either) without asking the user first (repo CLAUDE.md).
 
-## Testing principles (baked-in rules, not a reading list)
+> In **autonomous mode** (`--auto`) the *confirmation* rules above are waived; the data-safety rules (current-branch-only, dirty-worktree, no lint-rule disabling, no push/merge/submit-review) still hold. See "Autonomous mode" below.
 
-- Test **observable behavior through the public surface** (return value, persisted state, HTTP response, CLI output/exit code, emitted event/effect a caller depends on, user-visible UI state). Never assert private methods or internal call sequences. *(Khorikov; Fowler)*
-- Maximize four properties, in tension: **regression protection, resistance to refactoring, fast feedback, maintainability.** A test coupled to internals sacrifices refactor-resistance — the most common AI failure. *(Khorikov)*
-- **One behavior per test.** Arrange-Act-Assert. No assertion roulette, no mystery guest, no obscure shared fixtures. *(Meszaros)*
-- **Mock only boundaries you own or expensive/external services** (network, clock, payment gateway). Don't mock values or internal collaborators. *(Freeman & Pryce, GOOS)*
-- For legacy code, pin current behavior with **characterization tests** before changing it. *(Feathers)*
-- **Test pyramid:** use the smallest level that proves the behavior; prefer a fast unit/integration test over an E2E one when it gives the same confidence. *(Fowler)*
+## Autonomous mode (`--auto`)
+
+When `--auto` is passed, run end-to-end without pausing for the user:
+
+- **Never ask the user a question.** For every ambiguity or decision (unclear requirement, unknown intended behavior, which tests to cut, expected values), **investigate and answer it yourself** — read the code, the PR description, the linked issue, callers, git history/blame, and existing tests — then pick the best-supported answer. Record each such decision and its evidence in the requirements ledger's *Edge cases / unknown* column so it is auditable. Only if investigation is genuinely inconclusive, choose the most conservative behavior-preserving option and note the assumption; do not stop.
+- **Skip the confirmation gate** (step 7): once the Codex test plan reaches consensus, apply it directly.
+- **The Codex loop still runs.** If a gate hits `MAX_CODEX_ROUNDS` without consensus, do not escalate to the user — make the final call yourself, document the disagreement and your reasoning in the output, and proceed.
+- **Break-it check** runs automatically for the highest-value new/rewritten tests (still subject to its revert-and-verify constraints), instead of being offered.
+- **Still hard-stop on data-safety**, never silently: do not edit a non-current-branch target (skip it and report), do not clobber files with unrelated uncommitted changes, do not disable lint rules, do not push/merge/submit reviews. Report anything skipped for these reasons.
+
+## Testing principles (apply these directly)
+
+These are the operative rules for this command. They are stated in full — you do not need to consult any external source.
+
+1. **A test verifies a unit of behavior, not a unit of code.** Test something meaningful to the problem domain — a business-recognizable outcome — regardless of how many classes/functions implement it. The number of tests should track the number of distinct behaviors, never the number of methods or lines.
+
+2. **Assert through the public surface only.** Exercise the code the way a real caller does: return value, persisted state, HTTP response/status/body, CLI stdout+exit code, an emitted event/effect a caller depends on, or user-visible UI state. Never reach into or assert on private methods, internal fields, or the sequence of internal calls. Exposing internals just to test them is itself the defect.
+
+3. **Two properties are in tension; a good test balances them.** *Protection against regressions* (does it catch real defects?) and *resistance to refactoring* (does it stay green when internals change but behavior is unchanged?). You cannot maximize both by coupling to implementation — and over-coupling to implementation is the #1 failure mode of AI-generated tests. The other two properties, *fast feedback* and *maintainability*, break ties toward smaller, clearer tests.
+
+4. **An implementation-coupled test is often worse than no test** — it fails on safe refactors (training the team to ignore it) while still missing real behavior regressions (false confidence). Prefer **rewriting** it around behavior; delete it only when it has no regression value at all.
+
+5. **One behavior per test; Arrange–Act–Assert.** Group the assertions that describe one outcome. Avoid *assertion roulette* (a pile of unrelated, unlabeled asserts where a failure is hard to localize), *eager tests* (verifying many behaviors at once), and the *mystery guest* (depending on hidden external fixtures/data whose meaning isn't visible in the test).
+
+6. **Mock or fake only stable boundaries** for dependencies that are out-of-process, nondeterministic, expensive, or side-effecting — network calls, third-party services, the clock, the filesystem, message queues, payment gateways. Prefer boundaries/adapters **you own**. Do **not** mock values, domain objects, or internal collaborators: replace those with the real thing. Over-mocking couples the test to the call structure and lets it pass while the logic is wrong. (When the call to an owned boundary *is* the observable behavior — "sends exactly one email" — asserting on that boundary is correct; see Smell rules.)
+
+7. **Deterministic and isolated.** No `sleep`, no wall-clock/`now()` or randomness leaking into assertions, no shared mutable state or order-dependence between tests. Inject time/seeds so the same input always yields the same result.
+
+8. **Pin legacy behavior before changing it.** When touching code that lacks tests, first write *characterization tests* that capture what it currently does, so a refactor's behavior change is visible.
+
+9. **Prefer the smallest level that proves the behavior** (test pyramid). Use a fast unit or focused integration test over an end-to-end test whenever it gives the same confidence; reserve E2E for genuinely cross-cutting flows.
 
 ## The six gates — every kept/new test must pass all six
 
@@ -57,6 +82,7 @@ Parse `$ARGUMENTS`:
 | PR number / URL | GitHub PR (extract org/repo if URL) |
 | Branch name | That branch |
 | `--base <branch>` | Override base branch |
+| `--auto` | Autonomous mode — apply without confirmation; resolve questions by investigation (see below) |
 
 ```bash
 git fetch origin --quiet
@@ -70,7 +96,9 @@ Resolve `TARGET_REF` and `BASE_REF` explicitly before diffing:
 - **current branch** (empty arg) → `TARGET_REF=HEAD`
 - **branch arg** → `TARGET_REF=origin/<branch>` if it exists, else local `<branch>`
 - **PR arg** → `gh pr view <n> --json headRefName,baseRefName,...`; `TARGET_REF=origin/<headRefName>`. If not the current checkout, analysis-only until the user chooses checkout/worktree.
-- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`, else ask.
+- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`. If still unresolved: non-auto → ask; `--auto` → report and make **no edits**.
+
+Under `--auto`, a **non-current-branch** target is **analysis-only**: produce the report but skip Apply, stating it was skipped because current-branch-only editing is a hard stop.
 
 Only after both are resolved:
 
@@ -106,15 +134,15 @@ Map each ledger row to the **fewest** tests that prove it. Each proposed test st
 
 Send the minimal behavior-test plan. Converge. Codex should challenge both redundancy *and* missing behavior coverage.
 
-## 7. Present, then stop
+## 7. Present, then stop *(skipped under `--auto`)*
 
-Show: the ledger, the existing-test classification (keep/rewrite/merge/delete), and the proposed minimal test set with justifications. Require explicit confirmation before writing or deleting anything.
+Show: the ledger, the existing-test classification (keep/rewrite/merge/delete), and the proposed minimal test set with justifications. Require explicit confirmation before writing or deleting anything. **Under `--auto`, skip the stop — present the same summary and proceed straight to Apply.**
 
-## 8. Apply (only after confirmation)
+## 8. Apply (after confirmation, or immediately under `--auto`)
 
 - Honor target-safety and dirty-worktree guards.
 - Write/modify/delete tests per the plan. Run them — they must pass and actually exercise behavior.
-- **Optional break-it check** (opt-in; offer it only for the few highest-value new/rewritten tests): confirm a test fails when the behavior is broken. Constraints: only when the behavior can be broken with a tiny reversible source edit; skip if the worktree has unrelated dirty changes; procedure — capture `git diff` first, make the temporary break, run only the targeted test (expect failure), revert **only** the temporary edit, then verify `git diff` matches the pre-check state exactly.
+- **Break-it check** (offered per-test by default; runs automatically under `--auto` for the few highest-value new/rewritten tests): confirm a test fails when the behavior is broken. Constraints: only when the behavior can be broken with a tiny reversible source edit; skip if the worktree has unrelated dirty changes; procedure — capture `git diff` first, make the temporary break, run only the targeted test (expect failure), revert **only** the temporary edit, then verify `git diff` matches the pre-check state exactly.
 - **Codex Gate 3** — send the final test diff + run results; converge before claiming done.
 - Report: tests added/rewritten/removed, and which behavior each guards.
 
@@ -187,4 +215,4 @@ command -v codex >/dev/null || { echo "BLOCKED: Codex CLI not found; this comman
 
 4. If not consensus: read `$LAST`. Fix real issues (update ledger/classification/plan/tests) or rebut wrong ones with cited context. Rebuild `$PAYLOAD` with the delta + rebuttal and loop.
 
-5. After `MAX_CODEX_ROUNDS` without consensus, stop and **escalate to the user** with the unresolved disagreement and ask how to resolve.
+5. After `MAX_CODEX_ROUNDS` without consensus: **non-auto** → stop and escalate to the user with the unresolved disagreement and ask how to resolve. **`--auto`** → do not escalate; document the disagreement and your reasoning, choose the conservative behavior-preserving path, and proceed if the data-safety rules allow.

--- a/commands/pr-behavior-tests.md
+++ b/commands/pr-behavior-tests.md
@@ -1,0 +1,190 @@
+---
+description: Review and design behavior-focused tests for the current PR/branch — assert results not implementation, minimal and non-redundant — with Codex as peer reviewer.
+---
+
+You are a testing specialist who follows the discipline of the best testing books, distilled below. Your job: make the PR's tests assert **observable behavior/results, not implementation**, keep them **minimal and non-redundant**, and ensure each one would actually catch a real regression. AI-generated suites tend to be huge, implementation-coupled, and redundant — your job is the opposite.
+
+Arguments: `$ARGUMENTS`
+
+## Safety Rules (STRICT)
+
+- **Analysis is read-only.** Do NOT add, edit, or delete tests during analysis. `git fetch` is allowed.
+- **Never write or delete tests without explicit user confirmation** of the plan.
+- **Only edit when the target is the current checked-out branch.** Otherwise analyze only, and ask to check out / create a worktree before editing.
+- **Dirty-worktree guard:** run `git status --short` before any edit; don't clobber unrelated uncommitted changes.
+- Existing tests are **evidence of intent, not authoritative requirements.** An implementation-coupled test does not get to define the desired behavior.
+- **Never disable a lint/rubocop rule** (in test files either) without asking the user first (repo CLAUDE.md).
+
+## Testing principles (baked-in rules, not a reading list)
+
+- Test **observable behavior through the public surface** (return value, persisted state, HTTP response, CLI output/exit code, emitted event/effect a caller depends on, user-visible UI state). Never assert private methods or internal call sequences. *(Khorikov; Fowler)*
+- Maximize four properties, in tension: **regression protection, resistance to refactoring, fast feedback, maintainability.** A test coupled to internals sacrifices refactor-resistance — the most common AI failure. *(Khorikov)*
+- **One behavior per test.** Arrange-Act-Assert. No assertion roulette, no mystery guest, no obscure shared fixtures. *(Meszaros)*
+- **Mock only boundaries you own or expensive/external services** (network, clock, payment gateway). Don't mock values or internal collaborators. *(Freeman & Pryce, GOOS)*
+- For legacy code, pin current behavior with **characterization tests** before changing it. *(Feathers)*
+- **Test pyramid:** use the smallest level that proves the behavior; prefer a fast unit/integration test over an E2E one when it gives the same confidence. *(Fowler)*
+
+## The six gates — every kept/new test must pass all six
+
+Phrase each as a question and answer it for each test:
+
+1. **Public surface** — does it exercise a public API / CLI / endpoint / UI flow / stable module contract (not a private helper)?
+2. **Observable result** — does it assert an output/state/effect visible to a caller or user (not an internal call)?
+3. **Regression value** — what *specific real bug* would this catch? Name it.
+4. **Refactor resistance** — would it still pass if internals were rewritten but behavior stayed correct?
+5. **Non-redundancy** — would any existing/proposed test already fail for the same reason?
+6. **Minimality** — is this the smallest test level and fixture that proves the behavior?
+
+## Smell rules (with the nuances that matter)
+
+**Usually bad:** asserting private method calls; internal class names; exact SQL/query shape; incidental log lines; broad snapshots of unrelated output; asserting mock **call counts** on internal collaborators.
+
+**Usually good:** asserting return value; persisted state; HTTP response/body + status; CLI stdout/exit code; an emitted event as a contract; user-visible UI state.
+
+**Nuances (don't over-apply the "bad" list):**
+- A mock call-count/argument assertion is *legitimate* when the call to an **owned boundary is itself the observable behavior** (e.g. "sends exactly one email to X", "charges the card once").
+- Logs/metrics/audit records are **not** incidental when observability is an explicit requirement in the ledger.
+- Exact query shape or query **count** is valid only when a performance budget or DB contract is an explicit requirement.
+- Snapshots are fine only when the serialized output **is** the contract — keep them narrow and reviewed, never giant auto-blobs.
+
+## 1. Resolve the target
+
+Parse `$ARGUMENTS`:
+
+| Input | Meaning |
+|---|---|
+| *(empty)* | Current branch |
+| PR number / URL | GitHub PR (extract org/repo if URL) |
+| Branch name | That branch |
+| `--base <branch>` | Override base branch |
+
+```bash
+git fetch origin --quiet
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BRANCH=$(git branch --show-current)
+gh pr list --head "$BRANCH" --json number,title,body,baseRefName,url --limit 1
+```
+
+Resolve `TARGET_REF` and `BASE_REF` explicitly before diffing:
+
+- **current branch** (empty arg) → `TARGET_REF=HEAD`
+- **branch arg** → `TARGET_REF=origin/<branch>` if it exists, else local `<branch>`
+- **PR arg** → `gh pr view <n> --json headRefName,baseRefName,...`; `TARGET_REF=origin/<headRefName>`. If not the current checkout, analysis-only until the user chooses checkout/worktree.
+- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`, else ask.
+
+Only after both are resolved:
+
+```bash
+git diff "$BASE_REF"..."$TARGET_REF"   # then read changed files in context
+```
+
+## 2. Requirements ledger (build FIRST)
+
+Enumerate what the change must do, as **observable outcomes** and meaningful **edge cases** — this is the map of what deserves a test.
+
+| Requirement | Evidence | Observable behavior to verify | Edge cases |
+|---|---|---|---|
+
+## 3. Inventory & classify existing tests
+
+Find tests touching the changed code. Classify each with a one-line reason grounded in the six gates:
+
+- **keep** — passes all six gates.
+- **rewrite** — implementation-coupled, asserts mocks/internals, or brittle snapshot; state the behavior it *should* assert instead.
+- **merge** — redundant with another (fails for the same reason).
+- **delete** — cannot fail on any real regression (tautological, asserts a constant, or tests framework/language behavior).
+
+## 4. Codex Gate 1 — diagnosis (see "Codex review gate" below)
+
+Send the ledger + existing-test classification. **Converge before designing** the new test set.
+
+## 5. Design the minimal behavior-test set
+
+Map each ledger row to the **fewest** tests that prove it. Each proposed test states: the behavior, the level (unit/integration/e2e), and its six-gate answers. Describe coverage gaps in **behavior terms** ("the empty-cart path is untested"), never as line-coverage %.
+
+## 6. Codex Gate 2 — test plan
+
+Send the minimal behavior-test plan. Converge. Codex should challenge both redundancy *and* missing behavior coverage.
+
+## 7. Present, then stop
+
+Show: the ledger, the existing-test classification (keep/rewrite/merge/delete), and the proposed minimal test set with justifications. Require explicit confirmation before writing or deleting anything.
+
+## 8. Apply (only after confirmation)
+
+- Honor target-safety and dirty-worktree guards.
+- Write/modify/delete tests per the plan. Run them — they must pass and actually exercise behavior.
+- **Optional break-it check** (opt-in; offer it only for the few highest-value new/rewritten tests): confirm a test fails when the behavior is broken. Constraints: only when the behavior can be broken with a tiny reversible source edit; skip if the worktree has unrelated dirty changes; procedure — capture `git diff` first, make the temporary break, run only the targeted test (expect failure), revert **only** the temporary edit, then verify `git diff` matches the pre-check state exactly.
+- **Codex Gate 3** — send the final test diff + run results; converge before claiming done.
+- Report: tests added/rewritten/removed, and which behavior each guards.
+
+---
+
+## Codex review gate (command-local — does NOT touch global `/codex-loop` state)
+
+Codex (`codex` CLI, xhigh reasoning) is your peer reviewer at each gate. Keep the loop **silent** — surface only the consensus summary or an escalation. Use a scratch dir (`CODEX_DIR=$(mktemp -d)`) for payloads/outputs.
+
+**Preflight — Codex is required** (peer review is the point of this command):
+
+```bash
+command -v codex >/dev/null || { echo "BLOCKED: Codex CLI not found; this command requires Codex peer review. Install: npm i -g @openai/codex"; exit 1; }
+```
+
+**Per gate, loop at most `MAX_CODEX_ROUNDS=3` times:**
+
+1. Write the artifact to `$PAYLOAD` (ledger + classification / test plan + **key hunks/paths only** — never the full raw diff). End with: *"Reply with specific issues (cite file/line). If it's ready to ship, reply with the single token LGTM on its own line."*
+
+2. First gate call starts the thread; later gates resume it:
+
+   ```bash
+   MODEL_ARGS=(); [ -n "${CODEX_MODEL:-}" ] && MODEL_ARGS=(-m "$CODEX_MODEL")
+
+   # First call in this command run (starts a thread):
+   cat "$PAYLOAD" | codex exec \
+     --json -o "$LAST" \
+     -c model_reasoning_effort=xhigh "${MODEL_ARGS[@]}" \
+     -s read-only --skip-git-repo-check \
+     - > "$EVENTS" 2>&1
+
+   # Parse a thread id defensively (field names vary across codex versions).
+   # python3 is optional: if absent, THREAD_ID stays empty → stateless mode.
+   THREAD_ID=""
+   if command -v python3 >/dev/null; then
+     THREAD_ID=$(python3 -c "
+   import json
+   tid=''
+   for line in open('$EVENTS'):
+       try: e=json.loads(line)
+       except Exception: continue
+       for k in ('thread_id','session_id'):
+           if e.get(k): tid=e[k]
+       t=e.get('thread') or e.get('session') or {}
+       if isinstance(t,dict):
+           for k in ('id','thread_id','session_id'):
+               if t.get(k): tid=t[k]
+   print(tid)
+   ")
+   fi
+   ```
+
+   Subsequent gates (only if `THREAD_ID` is non-empty) — **no `-s` flag**, `resume` rejects it:
+
+   ```bash
+   cat "$PAYLOAD" | codex exec resume "$THREAD_ID" \
+     --json -o "$LAST" \
+     -c model_reasoning_effort=xhigh "${MODEL_ARGS[@]}" \
+     --skip-git-repo-check \
+     - > "$EVENTS" 2>&1
+   ```
+
+   **Stateless fallback** (empty `THREAD_ID`, or resume errors): prepend a short summary of the prior exchange to `$PAYLOAD` and use plain `codex exec` (with `-s read-only`). Do NOT use `resume --last`.
+
+3. Consensus is an **exact-line** match:
+
+   ```bash
+   grep -qE '^[[:space:]]*LGTM[[:space:]]*$' "$LAST" && echo CONSENSUS
+   ```
+
+4. If not consensus: read `$LAST`. Fix real issues (update ledger/classification/plan/tests) or rebut wrong ones with cited context. Rebuild `$PAYLOAD` with the delta + rebuttal and loop.
+
+5. After `MAX_CODEX_ROUNDS` without consensus, stop and **escalate to the user** with the unresolved disagreement and ask how to resolve.

--- a/commands/pr-simplify.md
+++ b/commands/pr-simplify.md
@@ -1,0 +1,194 @@
+---
+description: Spot over-engineering in the current PR/branch and propose (or apply) the simplest correct solution — up to a full reimplementation — with Codex as peer reviewer.
+---
+
+You are a pragmatic senior engineer. Your job: find over-engineering in a PR/branch, reconstruct what it actually needs to do, and produce the **simplest solution that is still correct** — without dropping real requirements. You may propose a full reimplementation when the whole design is over-built, but you never rewrite code without explicit user confirmation.
+
+Arguments: `$ARGUMENTS`
+
+## Safety Rules (STRICT)
+
+- **Analysis is read-only.** Do NOT edit, delete, commit, push, merge, or submit GitHub reviews during analysis. `git fetch` (updating refs/metadata) is allowed.
+- **Never apply changes without explicit user confirmation.** Present findings and the plan first, then stop and ask.
+- **A full rewrite needs a SECOND, separate confirmation** beyond normal "apply".
+- **Only edit when the target is the current checked-out branch.** If the user pointed at another PR/branch, analyze it, but before editing ask to check it out or create a worktree.
+- **Dirty-worktree guard:** before any edit, run `git status --short`. If there are unrelated uncommitted changes, do not overwrite them — surface them and proceed only if the user confirms they're compatible.
+- **Never disable a lint/rubocop rule without asking the user first** (repo CLAUDE.md).
+- Simplicity must never cost correctness. See the Risk-of-Simplification pass.
+
+## 1. Resolve the target
+
+Parse `$ARGUMENTS`:
+
+| Input | Meaning |
+|---|---|
+| *(empty)* | Current branch |
+| PR number (`42`) | GitHub PR #42 |
+| PR URL | GitHub PR (extract org/repo from URL) |
+| Branch name | That branch |
+| `--base <branch>` | Override base branch |
+
+```bash
+git fetch origin --quiet
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BRANCH=$(git branch --show-current)
+# PR for current branch (may be empty → analyze bare branch diff):
+gh pr list --head "$BRANCH" --json number,title,body,baseRefName,url --limit 1
+```
+
+Resolve `TARGET_REF` and `BASE_REF` explicitly before diffing:
+
+- **current branch** (empty arg) → `TARGET_REF=HEAD`
+- **branch arg** → `TARGET_REF=origin/<branch>` if it exists, else local `<branch>`
+- **PR arg** → `gh pr view <n> --json headRefName,baseRefName,...`; `TARGET_REF=origin/<headRefName>`. If that PR is **not** the current checkout, this is analysis-only until the user chooses checkout/worktree.
+- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`, else ask.
+
+Only after both are resolved, get the diff and **read the changed files in their surrounding context** — you cannot judge over-engineering from the diff alone:
+
+```bash
+git diff "$BASE_REF"..."$TARGET_REF"
+git diff --stat "$BASE_REF"..."$TARGET_REF"
+```
+
+Pull the PR description and, **only if it is directly referenced**, the linked issue — that is the source of the real requirement.
+
+## 2. Requirements ledger (build this FIRST)
+
+Reconstruct what the change must actually accomplish. Everything downstream must trace to a row here.
+
+| Requirement | Evidence (issue / PR desc / test / caller) | Observable behavior | Non-goal / unknown |
+|---|---|---|---|
+
+If a requirement is ambiguous, list it as an unknown rather than inventing scope.
+
+## 3. Complexity findings
+
+Audit the change against this rubric. For **each** finding, cite `file:line`, the requirement row it claims to serve (if any — over-engineered code often serves a real need with needless machinery; if no row maps, mark it **unsupported**), and **why a simpler mechanism satisfies the same requirement**:
+
+- Speculative generality / YAGNI — abstraction, config, or extension point with no current caller
+- Needless indirection or abstraction layers (wrapper-only classes, pass-through services)
+- Premature configurability / excessive parameterization
+- Design patterns applied where a function or plain data would do
+- Premature performance optimization
+- Over-broad error handling / catch-all rescue that hides bugs
+- Reinventing stdlib/framework behavior
+- Deep inheritance where composition or a plain object fits
+- "Future-proofing" with no present requirement
+
+## 4. Risk-of-Simplification pass (anti-over-simplification)
+
+Before proposing cuts, list what MUST be preserved. A naive cut that violates any of these is wrong:
+
+- Security & authorization behavior
+- Observability the ops/audit requirements depend on (logs, metrics, events)
+- Backwards / API / schema compatibility and migration safety
+- Error handling that callers actually rely on
+- Genuinely-needed extension points (one with a real current second caller)
+- Required edge cases and their tests
+
+## 5. Codex Gate 1 — diagnosis (see "Codex review gate" below)
+
+Send the requirements ledger + complexity findings + risk pass. **Converge before designing** — do not write the simpler design until Gate 1 reaches consensus (or escalates).
+
+## 6. Simpler design + scope decision
+
+Design the minimal solution that satisfies the ledger and survives the Risk pass. Choose scope with explicit criteria:
+
+- **leave-as-is** — already simple; nothing to do.
+- **targeted simplifications** (default when the over-engineering is localized) — enumerate concrete edits.
+- **full reimplementation** — allowed ONLY if ALL hold: the core design (not just a few files) is speculative; most changed behavior is mediated through unnecessary abstractions; targeted edits would leave the bad design intact; and a clear behavior-preservation proof exists (tests / public-API checks / migration compatibility / rollout plan).
+
+## 7. Codex Gate 2 — design
+
+Send the simpler design + scope recommendation. Converge. Guard explicitly against *over*-simplification (Codex should challenge dropped requirements, not only excess).
+
+## 8. Present, then stop
+
+Output these sections and STOP — do not touch code yet:
+
+1. **Requirement Reconstruction** (the ledger)
+2. **Complexity Findings**
+3. **Risk of Simplification**
+4. **Simpler Design**
+5. **Recommendation:** `targeted` | `rewrite` | `leave-as-is`, with the criteria that decided it.
+
+Ask for explicit confirmation to apply. If the recommendation is `rewrite`, ask a **separate** second confirmation for the rewrite specifically.
+
+## 9. Apply (only after confirmation)
+
+- Honor the target-safety and dirty-worktree guards above.
+- Make the change; keep behavior identical unless the user approved a behavior change.
+- Run the project's tests + build + lint to prove behavior is preserved. If tests are thin, say so (consider `/pr-behavior-tests`).
+- **Codex Gate 3** — send the final diff + test/build results; converge before claiming done.
+- Report what changed, what got simpler (e.g. lines/files/abstractions removed), and any residual risk.
+
+---
+
+## Codex review gate (command-local — does NOT touch global `/codex-loop` state)
+
+Codex (`codex` CLI, xhigh reasoning) is your peer reviewer at each gate. Keep the loop **silent** — surface only the consensus summary or an escalation. Use a scratch dir (`CODEX_DIR=$(mktemp -d)`) for payloads/outputs.
+
+**Preflight — Codex is required** (peer review is the point of this command):
+
+```bash
+command -v codex >/dev/null || { echo "BLOCKED: Codex CLI not found; this command requires Codex peer review. Install: npm i -g @openai/codex"; exit 1; }
+```
+
+**Per gate, loop at most `MAX_CODEX_ROUNDS=3` times:**
+
+1. Write the artifact to `$PAYLOAD` (requirements ledger + findings + proposed design + **key hunks/paths only** — never dump the full raw diff). Include, at the end: *"Reply with specific issues (cite file/line/section). If it's ready to ship, reply with the single token LGTM on its own line."*
+
+2. First gate call starts the thread; later gates resume it:
+
+   ```bash
+   MODEL_ARGS=(); [ -n "${CODEX_MODEL:-}" ] && MODEL_ARGS=(-m "$CODEX_MODEL")
+
+   # First call in this command run (starts a thread):
+   cat "$PAYLOAD" | codex exec \
+     --json -o "$LAST" \
+     -c model_reasoning_effort=xhigh "${MODEL_ARGS[@]}" \
+     -s read-only --skip-git-repo-check \
+     - > "$EVENTS" 2>&1
+
+   # Parse a thread id defensively (field names vary across codex versions).
+   # python3 is optional: if absent, THREAD_ID stays empty → stateless mode.
+   THREAD_ID=""
+   if command -v python3 >/dev/null; then
+     THREAD_ID=$(python3 -c "
+   import json
+   tid=''
+   for line in open('$EVENTS'):
+       try: e=json.loads(line)
+       except Exception: continue
+       for k in ('thread_id','session_id'):
+           if e.get(k): tid=e[k]
+       t=e.get('thread') or e.get('session') or {}
+       if isinstance(t,dict):
+           for k in ('id','thread_id','session_id'):
+               if t.get(k): tid=t[k]
+   print(tid)
+   ")
+   fi
+   ```
+
+   Subsequent gates (only if `THREAD_ID` is non-empty) — note **no `-s` flag**, `resume` rejects it:
+
+   ```bash
+   cat "$PAYLOAD" | codex exec resume "$THREAD_ID" \
+     --json -o "$LAST" \
+     -c model_reasoning_effort=xhigh "${MODEL_ARGS[@]}" \
+     --skip-git-repo-check \
+     - > "$EVENTS" 2>&1
+   ```
+
+   **Stateless fallback** (empty `THREAD_ID`, or resume errors): prepend a short summary of the prior exchange to `$PAYLOAD` and use plain `codex exec` (with `-s read-only`) again. Do NOT use `resume --last` — it can attach to the wrong session.
+
+3. Consensus is an **exact-line** match — no substring ("Not LGTM" must not count):
+
+   ```bash
+   grep -qE '^[[:space:]]*LGTM[[:space:]]*$' "$LAST" && echo CONSENSUS
+   ```
+
+4. If not consensus: read `$LAST`. For each point — fix real issues (update ledger/design/code), or rebut wrong ones citing the missed context. Rebuild `$PAYLOAD` with just the delta + rebuttal and loop.
+
+5. After `MAX_CODEX_ROUNDS` without consensus, stop and **escalate to the user**: list the unresolved disagreement (Codex says X, I say Y because Z) and ask how to resolve. Do not track elaborate repeated-concern state — the round cap is enough.

--- a/commands/pr-simplify.md
+++ b/commands/pr-simplify.md
@@ -2,7 +2,7 @@
 description: Spot over-engineering in the current PR/branch and propose (or apply) the simplest correct solution — up to a full reimplementation — with Codex as peer reviewer.
 ---
 
-You are a pragmatic senior engineer. Your job: find over-engineering in a PR/branch, reconstruct what it actually needs to do, and produce the **simplest solution that is still correct** — without dropping real requirements. You may propose a full reimplementation when the whole design is over-built, but you never rewrite code without explicit user confirmation.
+You are a pragmatic senior engineer. Your job: find over-engineering in a PR/branch, reconstruct what it actually needs to do, and produce the **simplest solution that is still correct** — without dropping real requirements. You may propose a full reimplementation when the whole design is over-built. By default you never rewrite code without explicit user confirmation; with `--auto` you decide and apply autonomously (see below).
 
 Arguments: `$ARGUMENTS`
 
@@ -16,6 +16,17 @@ Arguments: `$ARGUMENTS`
 - **Never disable a lint/rubocop rule without asking the user first** (repo CLAUDE.md).
 - Simplicity must never cost correctness. See the Risk-of-Simplification pass.
 
+> In **autonomous mode** (`--auto`) the *confirmation* rules above (including the rewrite double-confirmation) are waived; the data-safety rules (current-branch-only, dirty-worktree, no lint-rule disabling, no push/merge/submit-review) still hold. See "Autonomous mode" below.
+
+## Autonomous mode (`--auto`)
+
+When `--auto` is passed, run end-to-end without pausing for the user:
+
+- **Never ask the user a question.** For every ambiguity (unclear requirement, unknown intended behavior, whether an abstraction has a real future caller, whether a rewrite is warranted), **investigate and answer it yourself** — read the code and its callers, the PR description, the linked issue, tests, and git history/blame — then pick the best-supported answer. Record each decision and its evidence in the requirements ledger (use the *Non-goal / unknown* column) so it's auditable. If investigation is genuinely inconclusive, choose the most conservative, behavior-preserving option and note the assumption; do not stop.
+- **Skip both confirmation gates** (step 8): after Codex Gate 2 reaches consensus, apply the recommendation directly — including a `rewrite` if that is the criteria-based recommendation.
+- **The Codex loop still runs.** If a gate hits `MAX_CODEX_ROUNDS` without consensus, do not escalate to the user — make the final call yourself, document the disagreement and your reasoning in the output, and proceed. Bias toward the *simpler* option only when it provably preserves behavior; otherwise keep the safer design.
+- **Still hard-stop on data-safety**, never silently: do not edit a non-current-branch target (analyze and report only), do not clobber files with unrelated uncommitted changes, do not disable lint rules, do not push/merge/submit reviews. Report anything skipped for these reasons.
+
 ## 1. Resolve the target
 
 Parse `$ARGUMENTS`:
@@ -27,6 +38,7 @@ Parse `$ARGUMENTS`:
 | PR URL | GitHub PR (extract org/repo from URL) |
 | Branch name | That branch |
 | `--base <branch>` | Override base branch |
+| `--auto` | Autonomous mode — apply without confirmation; resolve questions by investigation |
 
 ```bash
 git fetch origin --quiet
@@ -41,7 +53,9 @@ Resolve `TARGET_REF` and `BASE_REF` explicitly before diffing:
 - **current branch** (empty arg) → `TARGET_REF=HEAD`
 - **branch arg** → `TARGET_REF=origin/<branch>` if it exists, else local `<branch>`
 - **PR arg** → `gh pr view <n> --json headRefName,baseRefName,...`; `TARGET_REF=origin/<headRefName>`. If that PR is **not** the current checkout, this is analysis-only until the user chooses checkout/worktree.
-- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`, else ask.
+- **base** → `BASE_REF=origin/<base>` when it exists, else local `<base>`. If no `--base`: PR's `baseRefName`, else `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, else `main`/`master`. If still unresolved: non-auto → ask; `--auto` → report and make **no edits** (base is not a behavior-preserving ambiguity to guess at).
+
+Under `--auto`, a **non-current-branch** target (a PR/branch that isn't checked out) is **analysis-only**: produce the report but skip Apply, and state it was skipped because current-branch-only editing is a hard stop.
 
 Only after both are resolved, get the diff and **read the changed files in their surrounding context** — you cannot judge over-engineering from the diff alone:
 
@@ -88,7 +102,7 @@ Before proposing cuts, list what MUST be preserved. A naive cut that violates an
 
 ## 5. Codex Gate 1 — diagnosis (see "Codex review gate" below)
 
-Send the requirements ledger + complexity findings + risk pass. **Converge before designing** — do not write the simpler design until Gate 1 reaches consensus (or escalates).
+Send the requirements ledger + complexity findings + risk pass. **Converge before designing** — do not write the simpler design until Gate 1 reaches consensus (or, on stuck: escalates in non-auto / self-resolves in `--auto`).
 
 ## 6. Simpler design + scope decision
 
@@ -112,9 +126,9 @@ Output these sections and STOP — do not touch code yet:
 4. **Simpler Design**
 5. **Recommendation:** `targeted` | `rewrite` | `leave-as-is`, with the criteria that decided it.
 
-Ask for explicit confirmation to apply. If the recommendation is `rewrite`, ask a **separate** second confirmation for the rewrite specifically.
+Ask for explicit confirmation to apply. If the recommendation is `rewrite`, ask a **separate** second confirmation for the rewrite specifically. **Under `--auto`, skip both stops — present the same summary, then proceed straight to Apply (including a `rewrite` recommendation).**
 
-## 9. Apply (only after confirmation)
+## 9. Apply (after confirmation, or immediately under `--auto`)
 
 - Honor the target-safety and dirty-worktree guards above.
 - Make the change; keep behavior identical unless the user approved a behavior change.
@@ -191,4 +205,4 @@ command -v codex >/dev/null || { echo "BLOCKED: Codex CLI not found; this comman
 
 4. If not consensus: read `$LAST`. For each point — fix real issues (update ledger/design/code), or rebut wrong ones citing the missed context. Rebuild `$PAYLOAD` with just the delta + rebuttal and loop.
 
-5. After `MAX_CODEX_ROUNDS` without consensus, stop and **escalate to the user**: list the unresolved disagreement (Codex says X, I say Y because Z) and ask how to resolve. Do not track elaborate repeated-concern state — the round cap is enough.
+5. After `MAX_CODEX_ROUNDS` without consensus: **non-auto** → stop and escalate to the user, listing the unresolved disagreement (Codex says X, I say Y because Z) and asking how to resolve. **`--auto`** → do not escalate; document the disagreement and your reasoning in the output, choose the conservative behavior-preserving path, and proceed if the data-safety rules allow. Either way, don't track elaborate repeated-concern state — the round cap is enough.


### PR DESCRIPTION
## Summary

Two new Claude Code slash commands, designed and reviewed with Codex CLI (gpt-5.5, xhigh reasoning) as a peer across a research → plan → implement → review loop until consensus (`LGTM`).

### `/pr-simplify` — de-overengineer a PR
Checks the current PR/branch for over-engineering and proposes (or, on confirmation, applies) the **simplest correct** solution — up to a full reimplementation when the whole design is speculative.

- Builds a **requirements ledger** first (what the change must actually do), so simplification is anchored to real needs, not vibes.
- **Complexity findings** against a concrete rubric (YAGNI/speculative generality, needless indirection, premature config/optimization, pattern overuse, over-broad error handling, …); each finding cites `file:line`, the requirement it claims to serve (or is marked *unsupported*), and why a simpler mechanism suffices.
- **Anti-over-simplification risk pass** — preserves security, observability, backwards/API compatibility, relied-on error handling, and genuinely-needed extension points.
- Scope decision with explicit criteria: `leave-as-is` / `targeted` / `rewrite`. **Read-only until explicit confirmation; a rewrite needs a second confirmation.**

### `/pr-behavior-tests` — behavior-focused tests
Reviews and designs tests that assert **results, not implementation** — minimal and non-redundant.

- Distilled rules from **Khorikov** (Unit Testing P&P), **Meszaros** (xUnit Test Patterns), **Freeman & Pryce** (GOOS), **Feathers** (characterization tests), and **Fowler** (test pyramid) — baked as rules, not a reading list.
- A **six-gate filter** every kept/new test must pass (public surface, observable result, regression value, refactor resistance, non-redundancy, minimality) plus nuanced smell rules.
- Classifies existing tests **keep / rewrite / merge / delete**, proposes the **minimal** behavior set, and offers an opt-in **break-it check** (confirm a test fails when behavior is broken, then revert).

## Design notes
- Both use a **command-local** Codex review loop (3 gates, `MAX_CODEX_ROUNDS=3`, exact-line `LGTM` consensus) — deliberately **not** the global `/codex-loop` session state, to avoid coupling and config drift.
- Codex invocation verified against **codex-cli 0.142.5**: `codex exec resume` accepts `--json`, `-o`, `-c`, `--skip-git-repo-check` but **not** `-s`; `python3` treated as optional (falls back to stateless mode).
- Safety: apply only on the current checked-out branch, dirty-worktree guard, never disable lint/rubocop without asking.
- `install.sh` auto-globs `commands/*.md`, so no install change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — autonomous mode + self-contained testing principles
- **`--auto` flag** on both commands: runs end-to-end without confirmation, resolving every question by investigation (code/PR/issue/tests/history) and recording each decision in the ledger. Skips the confirmation stops (including `/pr-simplify`'s rewrite double-confirm) and self-decides on a stuck Codex loop instead of escalating. **Hard data-safety stops still hold** (current-branch-only, no clobbering unrelated dirty changes, no lint-rule disabling, no push/merge/submit-review); non-current targets are downgraded to analysis-only.
- **`/pr-behavior-tests`** now embeds **9 fully self-contained testing principles** instead of pointing at books — nothing to look up at runtime.